### PR TITLE
로그인 기능 전체적인 수정

### DIFF
--- a/pyeon/src/main/java/com/pyeon/domain/auth/config/SecurityConfig.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.pyeon.domain.auth.config;
 import com.pyeon.domain.auth.filter.JwtAuthenticationFilter;
 import com.pyeon.domain.auth.handler.JwtAccessDeniedHandler;
 import com.pyeon.domain.auth.handler.JwtAuthenticationEntryPoint;
+import com.pyeon.domain.auth.handler.OAuth2AuthenticationSuccessHandler;
+import com.pyeon.domain.auth.service.CustomOAuth2UserService;
 import com.pyeon.domain.auth.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -37,6 +39,8 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final JwtAccessDeniedHandler accessDeniedHandler;
     private final JwtAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 
     /**
      * Spring Security FilterChain 설정
@@ -62,7 +66,7 @@ public class SecurityConfig {
                 // URL별 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 경로 설정
-                        .requestMatchers("/api/auth/**", "/api/posts").permitAll()
+                        .requestMatchers("/api/auth/**", "/oauth2/**", "/api/test/**").permitAll()
                         // 관리자 권한이 필요한 경로 설정
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         // 그 외 모든 요청은 인증 필요
@@ -71,6 +75,13 @@ public class SecurityConfig {
                 // JWT 인증 필터 추가
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
                         UsernamePasswordAuthenticationFilter.class)
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                )
                 // 예외 처리 설정
                 .exceptionHandling(exception -> exception
                         .accessDeniedHandler(accessDeniedHandler)  // 권한 부족 시 처리

--- a/pyeon/src/main/java/com/pyeon/domain/auth/domain/UserPrincipal.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/domain/UserPrincipal.java
@@ -3,29 +3,47 @@ package com.pyeon.domain.auth.domain;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 @Getter
-public class UserPrincipal implements UserDetails {
+public class UserPrincipal implements OAuth2User, UserDetails {
     private final Long id;
     private final String email;
+    private final String nickname;
+    private final String profileImageUrl;
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public UserPrincipal(Long id, String email, Collection<? extends GrantedAuthority> authorities) {
+    public UserPrincipal(
+            Long id, 
+            String email, 
+            String nickname,
+            String profileImageUrl,
+            Collection<? extends GrantedAuthority> authorities
+    ) {
         this.id = id;
         this.email = email;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
         this.authorities = authorities;
     }
 
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return authorities;
+    public Map<String, Object> getAttributes() {
+        return Collections.emptyMap();  // OAuth2 attributes는 더 이상 저장할 필요 없음
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(id);
     }
 
     @Override
     public String getPassword() {
-        return null; // OAuth2 로그인이므로 패스워드 불필요
+        return null;  // OAuth2 로그인이므로 패스워드 불필요
     }
 
     @Override

--- a/pyeon/src/main/java/com/pyeon/domain/auth/dto/response/AuthUserResponse.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/dto/response/AuthUserResponse.java
@@ -1,0 +1,25 @@
+package com.pyeon.domain.auth.dto.response;
+
+import com.pyeon.domain.auth.domain.UserPrincipal;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+public class AuthUserResponse {
+    private final Long id;
+    private final String email;
+    private final String nickname;
+    private final String profileImageUrl;
+    private final String authority;
+
+    public AuthUserResponse(UserPrincipal userPrincipal) {
+        this.id = userPrincipal.getId();
+        this.email = userPrincipal.getEmail();
+        this.nickname = userPrincipal.getNickname();
+        this.profileImageUrl = userPrincipal.getProfileImageUrl();
+        this.authority = userPrincipal.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElse(null);
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/auth/dto/response/TokenResponse.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,10 @@
+package com.pyeon.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,51 @@
+package com.pyeon.domain.auth.handler;
+
+import com.pyeon.domain.auth.dto.response.TokenResponse;
+import com.pyeon.domain.auth.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+import java.io.IOException;
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final AuthService authService;
+    
+    @Value("${app.oauth2.authorized-redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+        TokenResponse tokenResponse = authService.createToken(oauth2User);
+
+        // 쿠키 생성
+        ResponseCookie cookie = ResponseCookie.from("accessToken", tokenResponse.getAccessToken())
+                .httpOnly(true)
+                .secure(true) // HTTPS에서만 전송
+                .sameSite("Lax") // CSRF 보호
+                .path("/") // 모든 경로에서 접근 가능
+                .maxAge(Duration.ofHours(1)) // JWT 만료시간과 동일하게 설정
+                .domain("localhost") // 개발 환경
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        // 토큰 없이 프론트엔드로 리다이렉트
+        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/auth/presentation/AuthController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/presentation/AuthController.java
@@ -1,0 +1,35 @@
+package com.pyeon.domain.auth.presentation;
+
+import com.pyeon.domain.auth.domain.UserPrincipal;
+import com.pyeon.domain.auth.dto.response.AuthUserResponse;
+import com.pyeon.domain.auth.dto.response.TokenResponse;
+import com.pyeon.domain.auth.service.AuthService;
+import com.pyeon.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<AuthUserResponse>> getCurrentUser(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        AuthUserResponse response = new AuthUserResponse(userPrincipal);
+        return ResponseEntity.ok(ApiResponse.success(response, 200));
+    }
+
+    @GetMapping("/login/google/callback")
+    public ResponseEntity<TokenResponse> googleCallback(
+            @RequestParam String code,
+            @RequestParam String state
+    ) {
+        TokenResponse tokenResponse = authService.googleLogin(code);
+        return ResponseEntity.ok(tokenResponse);
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/auth/service/AuthService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/service/AuthService.java
@@ -1,0 +1,46 @@
+package com.pyeon.domain.auth.service;
+
+import com.pyeon.domain.auth.domain.UserPrincipal;
+import com.pyeon.domain.auth.dto.response.TokenResponse;
+import com.pyeon.domain.auth.util.JwtProvider;
+import com.pyeon.domain.member.dao.MemberRepository;
+import com.pyeon.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public TokenResponse googleLogin(String code) {
+        // OAuth2 인증은 SecurityConfig에서 처리되므로, 
+        // 여기서는 토큰 발급만 처리합니다.
+        throw new UnsupportedOperationException(
+            "OAuth2 로그인은 /oauth2/authorization/google로 리다이렉트하여 처리해야 합니다."
+        );
+    }
+
+    @Transactional
+    public TokenResponse createToken(OAuth2User oauth2User) {
+        UserPrincipal userPrincipal = (UserPrincipal) oauth2User;
+        
+        String accessToken = jwtProvider.createAccessToken(userPrincipal);
+        
+        return new TokenResponse(accessToken);
+    }
+
+    private Member createMember(Map<String, Object> attributes) {
+        return memberRepository.save(Member.builder()
+                .email((String) attributes.get("email"))
+                .nickname((String) attributes.get("name"))
+                .profileImageUrl((String) attributes.get("picture"))
+                .build());
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/auth/service/CustomOAuth2UserService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,69 @@
+package com.pyeon.domain.auth.service;
+
+import com.pyeon.domain.auth.domain.Authority;
+import com.pyeon.domain.auth.domain.UserPrincipal;
+import com.pyeon.domain.member.dao.MemberRepository;
+import com.pyeon.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oauth2User = super.loadUser(userRequest);
+        
+        try {
+            return this.process(userRequest, oauth2User);
+        } catch (Exception ex) {
+            log.error("OAuth2 로그인 처리 중 에러 발생: ", ex);
+            throw new OAuth2AuthenticationException(ex.getMessage());
+        }
+    }
+
+    private OAuth2User process(OAuth2UserRequest userRequest, OAuth2User oauth2User) {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        
+        if (!"google".equals(registrationId)) {
+            throw new OAuth2AuthenticationException("Google 로그인만 지원합니다");
+        }
+
+        Map<String, Object> attributes = oauth2User.getAttributes();
+        
+        String email = (String) attributes.get("email");
+        if (!Boolean.TRUE.equals(attributes.get("email_verified"))) {
+            throw new OAuth2AuthenticationException("이메일 인증이 필요합니다");
+        }
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseGet(() -> createMember(attributes));
+
+        return new UserPrincipal(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getProfileImageUrl(),
+                Collections.singleton(member.getAuthority())
+        );
+    }
+
+    private Member createMember(Map<String, Object> attributes) {
+        return memberRepository.save(Member.builder()
+                .email((String) attributes.get("email"))
+                .nickname((String) attributes.get("name"))
+                .profileImageUrl((String) attributes.get("picture"))
+                .build());
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/auth/service/CustomUserDetailsService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/service/CustomUserDetailsService.java
@@ -25,6 +25,8 @@ public class CustomUserDetailsService implements UserDetailsService {
         return new UserPrincipal(
                 member.getId(),
                 member.getEmail(),
+                member.getNickname(),
+                member.getProfileImageUrl(),
                 Collections.singleton(member.getAuthority())
         );
     }

--- a/pyeon/src/main/java/com/pyeon/domain/member/domain/Member.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/domain/Member.java
@@ -22,30 +22,24 @@ public class Member extends BaseTimeEntity {
 
     private String nickname;
 
-    private String profileImage;
+    @Column(length = 2000)
+    private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Authority authority;
 
-    @Column(length = 2000)
-    private String refreshToken;
-
     @Builder
-    public Member(String email, String nickname, String profileImage) {
+    public Member(String email, String nickname, String profileImageUrl) {
         this.email = email;
         this.nickname = nickname;
-        this.profileImage = profileImage;
+        this.profileImageUrl = profileImageUrl;
         this.authority = Authority.ROLE_USER;  // 기본 권한은 USER
     }
 
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
-    public void updateProfile(String nickname, String profileImage) {
+    public void updateProfile(String nickname, String profileImageUrl) {
         this.nickname = nickname;
-        this.profileImage = profileImage;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public void promoteToAdmin() {

--- a/pyeon/src/main/java/com/pyeon/domain/post/dao/PostRepository.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dao/PostRepository.java
@@ -1,4 +1,8 @@
 package com.pyeon.domain.post.dao;
 
-public class PostRepository {
+import com.pyeon.domain.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
 }

--- a/pyeon/src/main/java/com/pyeon/domain/post/domain/Comment.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/domain/Comment.java
@@ -1,5 +1,6 @@
 package com.pyeon.domain.post.domain;
 
+import com.pyeon.domain.member.domain.Member;
 import com.pyeon.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -19,8 +20,9 @@ public class Comment extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @Column(nullable = false, length = 50)
-    private String author;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
@@ -29,15 +31,19 @@ public class Comment extends BaseTimeEntity {
     @Builder
     public Comment(
             String content,
-            String author,
+            Member member,
             Post post
     ) {
         this.content = content;
-        this.author = author;
+        this.member = member;
         this.post = post;
     }
 
     public void update(String content) {
         this.content = content;
+    }
+
+    public boolean isAuthor(String email) {
+        return member.getEmail().equals(email);
     }
 }

--- a/pyeon/src/main/java/com/pyeon/domain/post/domain/post.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/domain/post.java
@@ -7,10 +7,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
-@@Entity
+@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "is_active = true")
+@SQLDelete(sql = "UPDATE post SET is_active = false WHERE id = ?")
 public class Post extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,6 +32,9 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false)
     private long likeCount;
 
+    @Column(nullable = false)
+    private boolean isActive;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -39,6 +46,7 @@ public class Post extends BaseTimeEntity {
         this.member = member;
         this.viewCount = 0;
         this.likeCount = 0;
+        this.isActive = true;
     }
 
     public void incrementViewCount() {
@@ -56,5 +64,9 @@ public class Post extends BaseTimeEntity {
 
     public boolean isAuthor(String email) {
         return member.getEmail().equals(email);
+    }
+
+    public void delete() {
+        this.isActive = false;
     }
 }

--- a/pyeon/src/main/java/com/pyeon/domain/post/dto/request/PostCreateRequest.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dto/request/PostCreateRequest.java
@@ -16,12 +16,18 @@ public class PostCreateRequest {
     private String content;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private PostCreateRequest(String title, String content) {
+    private PostCreateRequest(
+            String title,
+            String content
+    ) {
         this.title = title;
         this.content = content;
     }
 
-    public static PostCreateRequest of(String title, String content) {
+    public static PostCreateRequest of(
+            String title,
+            String content
+    ) {
         return PostCreateRequest.builder()
                 .title(title)
                 .content(content)

--- a/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostResponse.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostResponse.java
@@ -14,22 +14,30 @@ public class PostResponse {
     private Long id;
     private String title;
     private String content;
-    private String authorEmail;
-    private String authorName;
+    private String memberEmail;
+    private String memberNickname;
     private long viewCount;
     private long likeCount;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private PostResponse(Long id, String title, String content, String authorEmail, 
-                        String authorName, long viewCount, long likeCount, 
-                        LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    private PostResponse(
+            Long id,
+            String title,
+            String content,
+            String memberEmail,
+            String memberNickname,
+            long viewCount,
+            long likeCount,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt
+    ) {
         this.id = id;
         this.title = title;
         this.content = content;
-        this.authorEmail = authorEmail;
-        this.authorName = authorName;
+        this.memberEmail = memberEmail;
+        this.memberNickname = memberNickname;
         this.viewCount = viewCount;
         this.likeCount = likeCount;
         this.createdAt = createdAt;
@@ -41,8 +49,8 @@ public class PostResponse {
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .authorEmail(post.getMember().getEmail())
-                .authorName(post.getMember().getNickname())
+                .memberEmail(post.getMember().getEmail())
+                .memberNickname(post.getMember().getNickname())
                 .viewCount(post.getViewCount())
                 .likeCount(post.getLikeCount())
                 .createdAt(post.getCreatedAt())

--- a/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostSummaryResponse.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostSummaryResponse.java
@@ -13,19 +13,24 @@ import java.time.LocalDateTime;
 public class PostSummaryResponse {
     private Long id;
     private String title;
-    private String authorName;
+    private String memberNickname;
     private long viewCount;
     private long likeCount;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private PostSummaryResponse(Long id, String title, String authorName, 
-                              long viewCount, long likeCount, 
-                              LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    private PostSummaryResponse(
+            Long id, String title,
+            String memberNickname,
+            long viewCount,
+            long likeCount,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt
+    ) {
         this.id = id;
         this.title = title;
-        this.authorName = authorName;
+        this.memberNickname = memberNickname;
         this.viewCount = viewCount;
         this.likeCount = likeCount;
         this.createdAt = createdAt;
@@ -36,7 +41,7 @@ public class PostSummaryResponse {
         return PostSummaryResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
-                .authorName(post.getMember().getNickname())
+                .memberNickname(post.getMember().getNickname())
                 .viewCount(post.getViewCount())
                 .likeCount(post.getLikeCount())
                 .createdAt(post.getCreatedAt())

--- a/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
@@ -1,10 +1,17 @@
 package com.pyeon.domain.post.presentation;
 
+import com.pyeon.domain.auth.domain.UserPrincipal;
+import com.pyeon.domain.post.dto.request.PostCreateRequest;
+import com.pyeon.domain.post.dto.request.PostUpdateRequest;
+import com.pyeon.domain.post.dto.response.PostResponse;
+import com.pyeon.domain.post.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
@@ -11,5 +11,11 @@ public interface PostService {
     PostResponse getPost(Long id);
     Page<PostResponse> getPosts(Pageable pageable);
     void updatePost(Long id, PostUpdateRequest request, String email);
+
+    boolean hasLiked(Long postId, String email);
+
+    void likePost(Long postId, String email);
+
     void deletePost(Long id, String email);
+
 }

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/PostServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/PostServiceImpl.java
@@ -1,7 +1,14 @@
 package com.pyeon.domain.post.service;
 
 import com.pyeon.domain.member.dao.MemberRepository;
+import com.pyeon.domain.member.domain.Member;
 import com.pyeon.domain.post.dao.PostRepository;
+import com.pyeon.domain.post.domain.Post;
+import com.pyeon.domain.post.dto.request.PostCreateRequest;
+import com.pyeon.domain.post.dto.request.PostUpdateRequest;
+import com.pyeon.domain.post.dto.response.PostResponse;
+import com.pyeon.global.exception.CustomException;
+import com.pyeon.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,6 +39,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    @Transactional
     public PostResponse getPost(Long id) {
         Post post = findPostById(id);
         post.incrementViewCount();
@@ -64,12 +72,12 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public void likePost(Long postId, String email) {
         String key = LIKE_KEY_PREFIX + postId;
-        Boolean isFirstLike = redisTemplate.opsForSet().add(key, email);
+        Long addResult = redisTemplate.opsForSet().add(key, email);
         
-        if (Boolean.TRUE.equals(isFirstLike)) {
+        if (addResult == 1) {  // 새로운 좋아요인 경우
             Post post = findPostById(postId);
             post.like();
-        } else {
+        } else {  // 이미 좋아요를 누른 경우
             throw new CustomException(ErrorCode.ALREADY_LIKED_POST);
         }
     }

--- a/pyeon/src/main/java/com/pyeon/global/config/RedisConfig.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/RedisConfig.java
@@ -3,6 +3,9 @@ package com.pyeon.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 @Configuration
 public class RedisConfig {

--- a/pyeon/src/main/java/com/pyeon/global/config/WebConfig.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.pyeon.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -10,5 +11,15 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addViewController("/").setViewName("index");
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")  // 프론트엔드 주소
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)  // 쿠키 전송 허용
+                .maxAge(3600);  // preflight 캐시 시간 (1시간)
     }
 }

--- a/pyeon/src/main/java/com/pyeon/global/exception/CustomException.java
+++ b/pyeon/src/main/java/com/pyeon/global/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.pyeon.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/pyeon/src/main/java/com/pyeon/global/exception/ErrorCode.java
+++ b/pyeon/src/main/java/com/pyeon/global/exception/ErrorCode.java
@@ -2,14 +2,29 @@ package com.pyeon.global.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 @Getter
 public enum ErrorCode {
+    // Common
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "올바르지 않은 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없는 페이지입니다."),
+    
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    
+    // Post
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
+    NOT_POST_AUTHOR(HttpStatus.FORBIDDEN, "게시글의 작성자가 아닙니다."),
+    ALREADY_LIKED_POST(HttpStatus.CONFLICT, "이미 추천한 게시글입니다."),
+    
+    // Auth
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다.");
 
-    INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
-    NOT_FOUND(1001, "찾을 수 없는 페이지입니다");
-
-    private final int status;
+    private final HttpStatus httpStatus;
     private final String message;
 }

--- a/pyeon/src/main/java/com/pyeon/global/exception/ErrorResponse.java
+++ b/pyeon/src/main/java/com/pyeon/global/exception/ErrorResponse.java
@@ -1,0 +1,99 @@
+package com.pyeon.global.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+    private int status;
+    private String message;
+    private List<FieldError> errors;
+
+    /**
+     * 에러 코드만으로 ErrorResponse 생성
+     */
+    private ErrorResponse(final ErrorCode errorCode) {
+        this.status = errorCode.getHttpStatus().value();
+        this.message = errorCode.getMessage();
+        this.errors = new ArrayList<>();
+    }
+
+    /**
+     * 에러 코드와 FieldError 리스트로 ErrorResponse 생성
+     */
+    private ErrorResponse(final ErrorCode errorCode, final List<FieldError> errors) {
+        this.status = errorCode.getHttpStatus().value();
+        this.message = errorCode.getMessage();
+        this.errors = errors;
+    }
+
+    /**
+     * 에러 코드로 ErrorResponse 생성
+     */
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
+    }
+
+    /**
+     * 에러 코드와 BindingResult로 ErrorResponse 생성
+     */
+    public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
+        return new ErrorResponse(errorCode, FieldError.from(bindingResult));
+    }
+
+    /**
+     * 에러 코드와 메시지로 ErrorResponse 생성
+     */
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        ErrorResponse response = new ErrorResponse(errorCode);
+        response.message = message;
+        return response;
+    }
+
+    /**
+     * API 검증 에러 정보를 담는 내부 클래스
+     */
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+        private String field;      // 에러가 발생한 필드명
+        private String value;      // 에러가 발생한 필드의 값
+        private String reason;     // 에러 발생 이유
+
+        private FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        /**
+         * BindingResult로부터 FieldError 리스트 생성
+         */
+        public static List<FieldError> from(final BindingResult bindingResult) {
+            return bindingResult.getFieldErrors()
+                    .stream()
+                    .map(error -> {
+                        String value;
+                        if (error.getRejectedValue() == null) {
+                            value = "";
+                        } else {
+                            value = error.getRejectedValue().toString();
+                        }
+                        
+                        return new FieldError(
+                                error.getField(),
+                                value,
+                                error.getDefaultMessage()
+                        );
+                    })
+                    .collect(Collectors.toList());
+        }
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/global/exception/GlobalExceptionHandler.java
+++ b/pyeon/src/main/java/com/pyeon/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.pyeon.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("CustomException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.from(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("BindException: {}", e.getMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST, e.getBindingResult()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Exception: ", e);
+        return ResponseEntity
+                .internalServerError()
+                .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST, "서버 오류가 발생했습니다."));
+    }
+} 

--- a/pyeon/src/test/java/com/pyeon/domain/auth/config/AuthIntegrationTest.java
+++ b/pyeon/src/test/java/com/pyeon/domain/auth/config/AuthIntegrationTest.java
@@ -1,0 +1,28 @@
+package com.pyeon.domain.auth.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void oauth2Login_리다이렉트() throws Exception {
+        mockMvc.perform(get("/oauth2/authorization/google"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().exists("Location"))
+                .andExpect(header().string("Location",
+                        org.hamcrest.Matchers.containsString(
+                                "https://accounts.google.com/o/oauth2/v2/auth")));
+    }
+}


### PR DESCRIPTION
## 작업 내용

1. OAuth2 로그인 구현
   - 구글 로그인 연동
   - 사용자 정보(이메일, 닉네임, 프로필 이미지) 저장
   - JWT 토큰 발급

2. JWT 토큰 관리 구현
   - HttpOnly 쿠키 기반 토큰 저장
   - JwtAuthenticationFilter를 통한 토큰 검증
   - 쿠키 기반 인증 처리

3. 사용자 인증 상태 확인 API 구현
   - /api/auth/me 엔드포인트 추가
   - 현재 로그인한 사용자 정보 제공
   - ApiResponse 형식으로 응답 통일

** 중요 **
원하는 방향대로 전체적인 틀은 잡았지만 AI 비중이 너무 높음
하나씩 디테일 하게 리팩토링 필요