### PR TITLE
회원 관리 및 게시글 조회 기능 구현

### DIFF
--- a/pyeon/src/main/java/com/pyeon/domain/member/dao/MemberRepository.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/dao/MemberRepository.java
@@ -13,8 +13,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);
-
-    // findByIdWithPosts 메서드 잠시 주석 처리
-    // @Query("SELECT m FROM Member m LEFT JOIN FETCH m.posts WHERE m.id = :id")
-    // Optional<Member> findByIdWithPosts(Long id);
 }

--- a/pyeon/src/main/java/com/pyeon/domain/member/dto/request/MemberUpdateRequest.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,35 @@
+package com.pyeon.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberUpdateRequest {
+    @NotBlank(message = "닉네임은 필수입니다")
+    private String nickname;
+    
+    private String profileImageUrl;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private MemberUpdateRequest(
+            final String nickname,
+            final String profileImageUrl
+    ) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public static MemberUpdateRequest of(
+            final String nickname,
+            final String profileImageUrl
+    ) {
+        return MemberUpdateRequest.builder()
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/member/dto/response/MemberResponse.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/dto/response/MemberResponse.java
@@ -1,0 +1,53 @@
+package com.pyeon.domain.member.dto.response;
+
+import com.pyeon.domain.auth.domain.Authority;
+import com.pyeon.domain.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberResponse {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+    private Authority authority;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private MemberResponse(
+            Long id,
+            String email,
+            String nickname,
+            String profileImageUrl,
+            Authority authority,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt
+    ) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.authority = authority;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .authority(member.getAuthority())
+                .createdAt(member.getCreatedAt())
+                .modifiedAt(member.getModifiedAt())
+                .build();
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/member/presentation/MemberController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/presentation/MemberController.java
@@ -1,0 +1,54 @@
+package com.pyeon.domain.member.presentation;
+
+import com.pyeon.domain.auth.domain.UserPrincipal;
+import com.pyeon.domain.member.dto.request.MemberUpdateRequest;
+import com.pyeon.domain.member.dto.response.MemberResponse;
+import com.pyeon.domain.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<MemberResponse> getMyInfo(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return ResponseEntity.ok(memberService.getMember(principal.getId()));
+    }
+
+    @GetMapping("/{memberId}")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<MemberResponse> getMember(
+            @PathVariable Long memberId
+    ) {
+        return ResponseEntity.ok(memberService.getMember(memberId));
+    }
+
+    @PutMapping("/me")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<Void> updateMyInfo(
+            @RequestBody @Valid MemberUpdateRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        memberService.updateMember(principal.getId(), request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/me")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<Void> deleteMyAccount(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        memberService.deleteMember(principal.getId());
+        return ResponseEntity.ok().build();
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/member/service/MemberService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/service/MemberService.java
@@ -1,0 +1,10 @@
+package com.pyeon.domain.member.service;
+
+import com.pyeon.domain.member.dto.request.MemberUpdateRequest;
+import com.pyeon.domain.member.dto.response.MemberResponse;
+
+public interface MemberService {
+    MemberResponse getMember(Long id);
+    void updateMember(Long id, MemberUpdateRequest request);
+    void deleteMember(Long id);
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/member/service/MemberServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/service/MemberServiceImpl.java
@@ -1,0 +1,46 @@
+package com.pyeon.domain.member.service;
+
+import com.pyeon.domain.member.dao.MemberRepository;
+import com.pyeon.domain.member.domain.Member;
+import com.pyeon.domain.member.dto.request.MemberUpdateRequest;
+import com.pyeon.domain.member.dto.response.MemberResponse;
+import com.pyeon.global.exception.CustomException;
+import com.pyeon.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberServiceImpl implements MemberService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberResponse getMember(Long id) {
+        Member member = findMemberById(id);
+        return MemberResponse.from(member);
+    }
+
+    @Override
+    @Transactional
+    public void updateMember(Long id, MemberUpdateRequest request) {
+        Member member = findMemberById(id);
+        member.updateProfile(
+                request.getNickname(),
+                request.getProfileImageUrl()
+        );
+    }
+
+    @Override
+    @Transactional
+    public void deleteMember(Long id) {
+        Member member = findMemberById(id);
+        member.delete();
+    }
+
+    private Member findMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/post/dao/PostRepository.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dao/PostRepository.java
@@ -2,6 +2,8 @@ package com.pyeon.domain.post.dao;
 
 import com.pyeon.domain.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {

--- a/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
@@ -92,4 +92,22 @@ public class PostController {
     ) {
         return ResponseEntity.ok(postService.hasLiked(postId, principal.getId()));
     }
+
+    @GetMapping("/my")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<Page<PostResponse>> getMyPosts(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(postService.getPostsByMemberId(principal.getId(), pageable));
+    }
+
+    @GetMapping("/members/{memberId}")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<Page<PostResponse>> getMemberPosts(
+            @PathVariable Long memberId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(postService.getPostsByMemberId(memberId, pageable));
+    }
 }

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
@@ -18,6 +18,9 @@ public interface PostService {
             boolean onlyPopular,
             Pageable pageable
     );
+
+    Page<PostResponse> getPostsByMemberId(Long memberId, Pageable pageable);
+    
     void updatePost(Long postId, PostUpdateRequest request, Long memberId);
     
     void deletePost(Long postId, Long memberId);

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/PostServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/PostServiceImpl.java
@@ -132,6 +132,18 @@ public class PostServiceImpl implements PostService {
         );
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PostResponse> getPostsByMemberId(Long memberId, Pageable pageable) {
+        Member member = findMemberById(memberId);
+        Specification<Post> spec = Specification.where((root, query, builder) ->
+            builder.equal(root.get("member"), member)
+        );
+        
+        return postRepository.findAll(spec, pageable)
+                .map(PostResponse::from);
+    }
+
     /**
      * Private 함수들
      */


### PR DESCRIPTION
# 회원 관리 및 게시글 조회 기능 구현

## 작업 내용

### 1. 회원 관리 기능 구현
- 회원 정보 조회 API
  - 자신의 정보 조회: `GET /api/members/me`
  - 특정 회원 정보 조회: `GET /api/members/{memberId}`
- 회원 정보 수정 API: `PUT /api/members/me`
  - 닉네임 및 프로필 이미지 수정 가능
- 회원 탈퇴 API: `DELETE /api/members/me`

### 2. 사용자별 게시글 조회 기능 구현
- 자신의 게시글 목록 조회: `GET /api/posts/my`
- 특정 회원의 게시글 목록 조회: `GET /api/posts/members/{memberId}`
- 페이징 처리 지원 (기본값: 최신순 10개)

## 기술적 결정사항
1. 회원 관련 API는 Member 도메인에서 관리
   - 회원 기본 정보 관리에 집중
   - CRUD 작업의 명확한 책임 분리

2. 게시글 조회 기능은 Post 도메인에서 관리
   - 게시글 조회의 일관성 유지
   - 기존 페이징, 정렬 기능 재사용
   - 향후 필터링/검색 기능 확장 용이
