### PR TITLE
refact: 좋아요 기능 및 Redis 설정 수정

### DIFF
--- a/pyeon/build.gradle
+++ b/pyeon/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.apache.commons:commons-pool2'
 }
 
 tasks.named('test') {

--- a/pyeon/docker-compose.dev.yml
+++ b/pyeon/docker-compose.dev.yml
@@ -10,8 +10,13 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/pyeon?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       - SPRING_DATASOURCE_USERNAME=${DEV_DB_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${DEV_DB_PASSWORD}
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_DATA_REDIS_PORT=6379
+      - SPRING_DATA_REDIS_PASSWORD=${DEV_REDIS_PASSWORD}
     depends_on:
       - db
+      - redis
+    restart: unless-stopped
 
   db:
     image: mysql:8.0
@@ -29,6 +34,17 @@ services:
     volumes:
       - mysql_data_dev:/var/lib/mysql
       - ./mysql/conf.d:/etc/mysql/conf.d
+    restart: unless-stopped
+
+  redis:
+    image: redis:7.0
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--requirepass", "${DEV_REDIS_PASSWORD}"]
+    volumes:
+      - redis_data_dev:/data
+    restart: unless-stopped
 
 volumes:
   mysql_data_dev:
+  redis_data_dev:

--- a/pyeon/src/main/java/com/pyeon/domain/post/domain/Post.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/domain/Post.java
@@ -68,6 +68,10 @@ public class Post extends BaseTimeEntity {
         this.likeCount++;
     }
 
+    public void unlike() {
+        this.likeCount = Math.max(0, this.likeCount - 1);  // 음수 방지
+    }
+
     public void update(
         final String title, 
         final String content, 

--- a/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostResponse.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostResponse.java
@@ -24,6 +24,7 @@ public class PostResponse {
     private LocalDateTime modifiedAt;
     private Category category;
     private List<CommentResponse> comments;
+    private boolean hasLiked;
 
     @Builder(access = AccessLevel.PRIVATE)
     private PostResponse(
@@ -37,7 +38,8 @@ public class PostResponse {
             LocalDateTime createdAt,
             LocalDateTime modifiedAt,
             Category category,
-            List<CommentResponse> comments
+            List<CommentResponse> comments,
+            boolean hasLiked
     ) {
         this.id = id;
         this.title = title;
@@ -50,9 +52,10 @@ public class PostResponse {
         this.modifiedAt = modifiedAt;
         this.category = category;
         this.comments = comments;
+        this.hasLiked = hasLiked;
     }
 
-    public static PostResponse from(Post post) {
+    public static PostResponse from(Post post, boolean hasLiked) {
         return PostResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -65,6 +68,11 @@ public class PostResponse {
                 .modifiedAt(post.getModifiedAt())
                 .category(post.getCategory())
                 .comments(post.getComments().stream().map(CommentResponse::from).toList())
+                .hasLiked(hasLiked)
                 .build();
+    }
+
+    public static PostResponse from(Post post) {
+        return from(post, false);
     }
 } 

--- a/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
@@ -35,11 +35,12 @@ public class PostController {
     }
 
     @GetMapping("/{postId}")
-    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<PostResponse> getPost(
-            @PathVariable(name = "postId") Long postId
+            @PathVariable(name = "postId") Long postId,
+            @AuthenticationPrincipal UserPrincipal principal
     ) {
-        PostResponse response = postService.getPost(postId);
+        Long memberId = principal != null ? principal.getId() : null;
+        PostResponse response = postService.getPost(postId, memberId);
         return ResponseEntity.ok(response);
     }
 
@@ -83,16 +84,7 @@ public class PostController {
         postService.likePost(postId, principal.getId());
         return ResponseEntity.ok().build();
     }
-
-    @GetMapping("/{postId}/like")
-    @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<Boolean> hasLiked(
-            @PathVariable(name = "postId") Long postId,
-            @AuthenticationPrincipal UserPrincipal principal
-    ) {
-        return ResponseEntity.ok(postService.hasLiked(postId, principal.getId()));
-    }
-
+    
     @GetMapping("/my")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Page<PostResponse>> getMyPosts(

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 public interface PostService {
     Long createPost(PostCreateRequest request, Long memberId);
     
-    PostResponse getPost(Long id);
+    PostResponse getPost(Long id, Long memberId);
 
     public Page<PostResponse> getPosts(
             Category category,
@@ -26,6 +26,4 @@ public interface PostService {
     void deletePost(Long postId, Long memberId);
     
     void likePost(Long postId, Long memberId);
-    
-    boolean hasLiked(Long postId, Long memberId);
 }

--- a/pyeon/src/main/java/com/pyeon/global/config/RedisConfig.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -15,9 +16,14 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.password}")
+    private String password;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
+        redisConfig.setPassword(password);
+        return new LettuceConnectionFactory(redisConfig);
     }
 
     @Bean

--- a/pyeon/src/main/java/com/pyeon/global/exception/ErrorCode.java
+++ b/pyeon/src/main/java/com/pyeon/global/exception/ErrorCode.java
@@ -41,7 +41,10 @@ public enum ErrorCode {
 
     // Comment 관련 에러
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "댓글을 찾을 수 없습니다."),
-    NOT_COMMENT_AUTHOR(HttpStatus.FORBIDDEN, "COMMENT_002", "댓글의 작성자가 아닙니다.");
+    NOT_COMMENT_AUTHOR(HttpStatus.FORBIDDEN, "COMMENT_002", "댓글의 작성자가 아닙니다."),
+    
+    // Redis 관련 에러
+    REDIS_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "REDIS_001", "Redis 서버 연결에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/pyeon/src/main/java/com/pyeon/global/exception/GlobalExceptionHandler.java
+++ b/pyeon/src/main/java/com/pyeon/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.pyeon.global.exception;
 
-import com.pyeon.global.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;


### PR DESCRIPTION
1. 좋아요 기능 개선
- Redis를 사용한 좋아요 상태 관리 구현
- 게시글 상세 조회 시 좋아요 상태 포함
- 게시글 삭제 시 Redis의 좋아요 데이터도 함께 삭제

2. API 설계 개선
- 불필요한 hasLiked API 엔드포인트 제거

3. 코드 가독성 개선
- hasLiked 메서드를 private으로 변경