### PR TITLE
feat: 이미지 업로드 기능 추가

### DIFF
--- a/pyeon/build.gradle
+++ b/pyeon/build.gradle
@@ -54,6 +54,11 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.apache.commons:commons-pool2'
+
+	// AWS S3
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.641'
+	implementation 'io.awspring.cloud:spring-cloud-aws-context:2.4.4'
+	implementation 'io.awspring.cloud:spring-cloud-aws-autoconfigure:2.4.4'
 }
 
 tasks.named('test') {

--- a/pyeon/src/main/java/com/pyeon/domain/image/domain/ImageFile.java
+++ b/pyeon/src/main/java/com/pyeon/domain/image/domain/ImageFile.java
@@ -1,0 +1,75 @@
+package com.pyeon.domain.image.domain;
+
+import com.pyeon.global.exception.ImageException;
+import com.pyeon.global.exception.ErrorCode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+public class ImageFile {
+
+    private static final String EXTENSION_DELIMITER = ".";
+
+    private final MultipartFile file;
+    private final String hashedName;
+
+    public ImageFile(final MultipartFile file) {
+        validateNullImage(file);
+        this.file = file;
+        this.hashedName = hashName(file);
+    }
+
+    private void validateNullImage(final MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ImageException(ErrorCode.NULL_IMAGE);
+        }
+    }
+
+    private String hashName(final MultipartFile image) {
+        final String name = image.getOriginalFilename();
+        final String filenameExtension = EXTENSION_DELIMITER + getFilenameExtension(name);
+        final String nameAndDate = name + LocalDateTime.now();
+        try {
+            final MessageDigest hashAlgorithm = MessageDigest.getInstance("SHA3-256");
+            final byte[] hashBytes = hashAlgorithm.digest(nameAndDate.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(hashBytes) + filenameExtension;
+        } catch (final NoSuchAlgorithmException e) {
+            throw new ImageException(ErrorCode.FAIL_IMAGE_NAME_HASH);
+        }
+    }
+
+    private String bytesToHex(final byte[] bytes) {
+        return IntStream.range(0, bytes.length)
+                .mapToObj(i -> String.format("%02x", bytes[i] & 0xff))
+                .collect(Collectors.joining());
+    }
+
+    private String getFilenameExtension(String filename) {
+        if (filename == null) {
+            return "";
+        }
+        int dotIndex = filename.lastIndexOf('.');
+        return (dotIndex == -1) ? "" : filename.substring(dotIndex + 1);
+    }
+
+    public String getContentType() {
+        return this.file.getContentType();
+    }
+
+    public long getSize() {
+        return this.file.getSize();
+    }
+
+    public InputStream getInputStream() throws IOException {
+        return this.file.getInputStream();
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/image/domain/S3ImageEvent.java
+++ b/pyeon/src/main/java/com/pyeon/domain/image/domain/S3ImageEvent.java
@@ -1,0 +1,11 @@
+package com.pyeon.domain.image.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class S3ImageEvent {
+
+    private final String imageName;
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/image/dto/response/ImageRes.java
+++ b/pyeon/src/main/java/com/pyeon/domain/image/dto/response/ImageRes.java
@@ -1,0 +1,17 @@
+package com.pyeon.domain.image.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ImageRes {
+
+    private String imageUrl;
+
+    public static ImageRes of(final String imageUrl) {
+        return new ImageRes(imageUrl);
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/image/infra/ImageUploader.java
+++ b/pyeon/src/main/java/com/pyeon/domain/image/infra/ImageUploader.java
@@ -1,0 +1,51 @@
+package com.pyeon.domain.image.infra;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import com.pyeon.domain.image.domain.ImageFile;
+import com.pyeon.global.exception.ImageException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import static com.pyeon.global.exception.ErrorCode.INVALID_IMAGE;
+import static com.pyeon.global.exception.ErrorCode.INVALID_IMAGE_PATH;
+
+@Component
+@RequiredArgsConstructor
+public class ImageUploader {
+
+    private static final String CACHE_CONTROL_VALUE = "max-age=3153600";
+
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.folder}")
+    private String folder;
+
+    public String uploadImage(final ImageFile imageFile) {
+        final String path = folder + imageFile.getHashedName();
+        final ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(imageFile.getContentType());
+        metadata.setContentLength(imageFile.getSize());
+        metadata.setCacheControl(CACHE_CONTROL_VALUE);
+
+        try (final InputStream inputStream = imageFile.getInputStream()) {
+            s3Client.putObject(bucket, path, inputStream, metadata);
+        } catch (final AmazonServiceException e) {
+            throw new ImageException(INVALID_IMAGE_PATH);
+        } catch (final IOException e) {
+            throw new ImageException(INVALID_IMAGE);
+        }
+
+        URL fileUrl = s3Client.getUrl(bucket, path);
+        return fileUrl.toString();
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/image/infra/S3ImageEventListener.java
+++ b/pyeon/src/main/java/com/pyeon/domain/image/infra/S3ImageEventListener.java
@@ -1,0 +1,42 @@
+package com.pyeon.domain.image.infra;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.pyeon.domain.image.domain.S3ImageEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3ImageEventListener {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.folder}")
+    private String folder;
+
+    @Async
+    @EventListener
+    public void handleS3ImageEvent(S3ImageEvent event) {
+        try {
+            final String imageName = event.getImageName();
+            final String path = folder + imageName;
+            
+            if (amazonS3.doesObjectExist(bucket, path)) {
+                amazonS3.deleteObject(bucket, path);
+                log.info("S3 이미지 삭제 성공: {}", path);
+            } else {
+                log.warn("S3 이미지가 존재하지 않음: {}", path);
+            }
+        } catch (Exception e) {
+            log.error("S3 이미지 삭제 실패: {}", e.getMessage(), e);
+        }
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/image/presentation/ImageController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/image/presentation/ImageController.java
@@ -1,0 +1,40 @@
+package com.pyeon.domain.image.presentation;
+
+import com.pyeon.domain.image.dto.response.ImageRes;
+import com.pyeon.domain.image.service.ImageService;
+import com.pyeon.global.exception.ErrorResponse;
+import com.pyeon.global.exception.ImageException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+
+import static com.pyeon.global.exception.ErrorCode.EXCEED_IMAGE_SIZE;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    public ResponseEntity<ImageRes> uploadImage(@RequestPart("image") MultipartFile image) {
+        final ImageRes imageResponse = imageService.save(image);
+        return ResponseEntity.created(URI.create(imageResponse.getImageUrl())).body(imageResponse);
+    }
+    
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        return ResponseEntity
+                .status(EXCEED_IMAGE_SIZE.getHttpStatus())
+                .body(ErrorResponse.from(EXCEED_IMAGE_SIZE));
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/image/service/ImageService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/image/service/ImageService.java
@@ -1,0 +1,8 @@
+package com.pyeon.domain.image.service;
+
+import com.pyeon.domain.image.dto.response.ImageRes;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageService {
+    ImageRes save(final MultipartFile image);
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/image/service/ImageServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/image/service/ImageServiceImpl.java
@@ -1,0 +1,51 @@
+package com.pyeon.domain.image.service;
+
+import com.pyeon.domain.image.domain.ImageFile;
+import com.pyeon.domain.image.domain.S3ImageEvent;
+import com.pyeon.domain.image.dto.response.ImageRes;
+import com.pyeon.domain.image.infra.ImageUploader;
+import com.pyeon.global.exception.ImageException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.pyeon.global.exception.ErrorCode.EMPTY_IMAGE;
+import static com.pyeon.global.exception.ErrorCode.EXCEED_IMAGE_SIZE;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+    private final ImageUploader imageUploader;
+    private final ApplicationEventPublisher publisher;
+
+    @Override
+    public ImageRes save(final MultipartFile image) {
+        validateImage(image);
+        final ImageFile imageFile = new ImageFile(image);
+        final String imageUrl = uploadImage(imageFile);
+        return new ImageRes(imageUrl);
+    }
+
+    private String uploadImage(final ImageFile imageFile) {
+        try {
+            return imageUploader.uploadImage(imageFile);
+        } catch (final ImageException e) {
+            publisher.publishEvent(new S3ImageEvent(imageFile.getHashedName()));
+            throw e;
+        }
+    }
+
+    private void validateImage(final MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new ImageException(EMPTY_IMAGE);
+        }
+        
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new ImageException(EXCEED_IMAGE_SIZE);
+        }
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/global/config/AsyncConfig.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.pyeon.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+} 

--- a/pyeon/src/main/java/com/pyeon/global/config/S3Config.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.pyeon.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/global/config/SecurityConfig.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                             "/error",
                             "/favicon.ico",
                             "/api/auth/**",
-                            "/oauth2/**"
+                            "/oauth2/**",
+                            "/api/images/**"
                         ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/posts").permitAll()

--- a/pyeon/src/main/java/com/pyeon/global/config/WebConfig.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.pyeon.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -17,4 +18,5 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true)  // 쿠키 전송 허용
                 .maxAge(3600);  // preflight 캐시 시간 (1시간)
     }
+    
 }

--- a/pyeon/src/main/java/com/pyeon/global/exception/ErrorCode.java
+++ b/pyeon/src/main/java/com/pyeon/global/exception/ErrorCode.java
@@ -48,7 +48,17 @@ public enum ErrorCode {
     NOT_COMMENT_AUTHOR(HttpStatus.FORBIDDEN, "COMMENT_002", "댓글의 작성자가 아닙니다."),
     
     // Redis 관련 에러
-    REDIS_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "REDIS_001", "Redis 서버 연결에 실패했습니다.");
+    REDIS_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "REDIS_001", "Redis 서버 연결에 실패했습니다."),
+    
+    // 이미지 관련 에러
+    NULL_IMAGE(HttpStatus.BAD_REQUEST, "IMG_001", "이미지가 없습니다."),
+    EMPTY_IMAGE(HttpStatus.BAD_REQUEST, "IMG_002", "이미지가 비어있습니다."),
+    INVALID_IMAGE(HttpStatus.BAD_REQUEST, "IMG_003", "유효하지 않은 이미지입니다."),
+    INVALID_IMAGE_PATH(HttpStatus.BAD_REQUEST, "IMG_004", "유효하지 않은 이미지 경로입니다."),
+    FAIL_IMAGE_NAME_HASH(HttpStatus.INTERNAL_SERVER_ERROR, "IMG_005", "이미지 이름 해싱에 실패했습니다."),
+    EMPTY_IMAGE_LIST(HttpStatus.BAD_REQUEST, "IMG_006", "이미지 목록이 비어있습니다."),
+    EXCEED_IMAGE_LIST_SIZE(HttpStatus.BAD_REQUEST, "IMG_007", "이미지 목록 크기를 초과했습니다."),
+    EXCEED_IMAGE_SIZE(HttpStatus.BAD_REQUEST, "IMG_008", "이미지 크기가 5MB를 초과했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/pyeon/src/main/java/com/pyeon/global/exception/ImageException.java
+++ b/pyeon/src/main/java/com/pyeon/global/exception/ImageException.java
@@ -1,0 +1,12 @@
+package com.pyeon.global.exception;
+
+public class ImageException extends CustomException {
+    
+    public ImageException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+    
+    public ImageException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+} 


### PR DESCRIPTION
## S3 설정 클래스 구현
   - AmazonS3 클라이언트 빈 등록
   - AWS 인증 정보 설정

## 도메인 모델 구현
   - ImageFile: 이미지 파일 정보와 해시된 파일명 관리
   - S3ImageEvent: 이미지 삭제 이벤트 정의

## 이미지 업로드 서비스 구현
   - 이미지 유효성 검증 (빈 파일, 크기 제한)
   - S3에 이미지 업로드 및 URL 반환
   - 예외 발생 시 이벤트 발행