### PR TITLE
refact: post 요구사항 변경에 따른 수정

### DIFF
--- a/pyeon/src/main/java/com/pyeon/domain/image/presentation/ImageController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/image/presentation/ImageController.java
@@ -26,7 +26,7 @@ public class ImageController {
     private final ImageService imageService;
 
     @PostMapping
-    public ResponseEntity<ImageRes> uploadImage(@RequestPart("image") MultipartFile image) {
+    public ResponseEntity<ImageRes> uploadImage(@RequestPart(name = "image") MultipartFile image) {
         final ImageRes imageResponse = imageService.save(image);
         return ResponseEntity.created(URI.create(imageResponse.getImageUrl())).body(imageResponse);
     }

--- a/pyeon/src/main/java/com/pyeon/domain/post/dao/PostSpecification.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dao/PostSpecification.java
@@ -1,6 +1,7 @@
 package com.pyeon.domain.post.dao;
 
-import com.pyeon.domain.post.domain.Category;
+import com.pyeon.domain.post.domain.enums.MainCategory;
+import com.pyeon.domain.post.domain.enums.SubCategory;
 import com.pyeon.domain.post.domain.Post;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
@@ -9,10 +10,17 @@ import org.springframework.util.StringUtils;
 @Component
 public class PostSpecification {
     
-    public static Specification<Post> withCategory(Category category) {
+    public static Specification<Post> withMainCategory(MainCategory mainCategory) {
         return (root, query, cb) -> {
-            if (category == null) return null;
-            return cb.equal(root.get("category"), category);
+            if (mainCategory == null) return null;
+            return cb.equal(root.get("mainCategory"), mainCategory);
+        };
+    }
+    
+    public static Specification<Post> withSubCategory(SubCategory subCategory) {
+        return (root, query, cb) -> {
+            if (subCategory == null) return null;
+            return cb.equal(root.get("subCategory"), subCategory);
         };
     }
     

--- a/pyeon/src/main/java/com/pyeon/domain/post/domain/Post.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/domain/Post.java
@@ -1,6 +1,8 @@
 package com.pyeon.domain.post.domain;
 
 import com.pyeon.domain.member.domain.Member;
+import com.pyeon.domain.post.domain.enums.MainCategory;
+import com.pyeon.domain.post.domain.enums.SubCategory;
 import com.pyeon.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -40,7 +42,11 @@ public class Post extends BaseTimeEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private Category category;
+    private MainCategory mainCategory;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SubCategory subCategory;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
@@ -50,11 +56,12 @@ public class Post extends BaseTimeEntity {
     private Member member;
 
     @Builder
-    public Post(String title, String content, Member member, Category category) {
+    public Post(String title, String content, Member member, MainCategory mainCategory, SubCategory subCategory) {
         this.title = title;
         this.content = content;
         this.member = member;
-        this.category = category;
+        this.mainCategory = mainCategory;
+        this.subCategory = subCategory;
         this.viewCount = 0;
         this.likeCount = 0;
         this.isActive = true;
@@ -75,11 +82,13 @@ public class Post extends BaseTimeEntity {
     public void update(
         final String title, 
         final String content, 
-        final Category category
+        final MainCategory mainCategory,
+        final SubCategory subCategory
     ) {
         this.title = title;
         this.content = content;
-        this.category = category;
+        this.mainCategory = mainCategory;
+        this.subCategory = subCategory;
     }
 
     public boolean isWriter(Member member) {

--- a/pyeon/src/main/java/com/pyeon/domain/post/domain/enums/MainCategory.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/domain/enums/MainCategory.java
@@ -1,16 +1,16 @@
-package com.pyeon.domain.post.domain;
+package com.pyeon.domain.post.domain.enums;
 
 import lombok.Getter;
 
 @Getter
-public enum Category {
+public enum MainCategory {
     RECRUITMENT("구인"),
     JOB_SEEKING("구직"),
     COMMUNITY("커뮤니티");
 
     private final String value;
 
-    Category(String value) {
+    MainCategory(String value) {
         this.value = value;
     }
-}
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/post/domain/enums/SubCategory.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/domain/enums/SubCategory.java
@@ -1,0 +1,35 @@
+package com.pyeon.domain.post.domain.enums;
+
+import com.pyeon.domain.post.domain.enums.MainCategory;
+import lombok.Getter;
+
+@Getter
+public enum SubCategory {
+    // 구인 ＆ 구직 서브 카테고리
+    EDITOR("편집자", MainCategory.RECRUITMENT, MainCategory.JOB_SEEKING),
+    THUMBNAILER("썸네일러", MainCategory.RECRUITMENT, MainCategory.JOB_SEEKING),
+    OTHER("기타", MainCategory.RECRUITMENT, MainCategory.JOB_SEEKING),
+
+    // 커뮤니티 서브 카테고리
+    ALL("전체", MainCategory.COMMUNITY),
+    FREE("자유", MainCategory.COMMUNITY),
+    QUESTION("질문", MainCategory.COMMUNITY),
+    INFORMATION("정보", MainCategory.COMMUNITY);
+
+    private final String value;
+    private final MainCategory[] mainCategories;
+
+    SubCategory(String value, MainCategory... mainCategories) {
+        this.value = value;
+        this.mainCategories = mainCategories;
+    }
+
+    public boolean belongsTo(MainCategory mainCategory) {
+        for (MainCategory category : mainCategories) {
+            if (category == mainCategory) {
+                return true;
+            }
+        }
+        return false;
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/post/dto/request/PostCreateRequest.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dto/request/PostCreateRequest.java
@@ -1,6 +1,7 @@
 package com.pyeon.domain.post.dto.request;
 
-import com.pyeon.domain.post.domain.Category;
+import com.pyeon.domain.post.domain.enums.MainCategory;
+import com.pyeon.domain.post.domain.enums.SubCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -17,29 +18,36 @@ public class PostCreateRequest {
     @NotBlank(message = "내용은 필수입니다")
     private String content;
 
-    @NotNull(message = "카테고리는 필수입니다")
-    private Category category;
+    @NotNull(message = "메인 카테고리는 필수입니다")
+    private MainCategory mainCategory;
+
+    @NotNull(message = "서브 카테고리는 필수입니다")
+    private SubCategory subCategory;
 
     @Builder(access = AccessLevel.PRIVATE)
     private PostCreateRequest(
             final String title,
             final String content,
-            final Category category
+            final MainCategory mainCategory,
+            final SubCategory subCategory
     ) {
         this.title = title;
         this.content = content;
-        this.category = category;
+        this.mainCategory = mainCategory;
+        this.subCategory = subCategory;
     }
 
     public static PostCreateRequest of(
             final String title,
             final String content,
-            final Category category
+            final MainCategory mainCategory,
+            final SubCategory subCategory
     ) {
         return PostCreateRequest.builder()
                 .title(title)
                 .content(content)
-                .category(category)
+                .mainCategory(mainCategory)
+                .subCategory(subCategory)
                 .build();
     }
 } 

--- a/pyeon/src/main/java/com/pyeon/domain/post/dto/request/PostUpdateRequest.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dto/request/PostUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.pyeon.domain.post.dto.request;
 
-import com.pyeon.domain.post.domain.Category;
+import com.pyeon.domain.post.domain.enums.MainCategory;
+import com.pyeon.domain.post.domain.enums.SubCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -17,29 +18,36 @@ public class PostUpdateRequest {
     @NotBlank(message = "내용은 필수입니다")
     private String content;
 
-    @NotNull(message = "카테고리는 필수입니다")
-    private Category category;
+    @NotNull(message = "메인 카테고리는 필수입니다")
+    private MainCategory mainCategory;
+
+    @NotNull(message = "서브 카테고리는 필수입니다")
+    private SubCategory subCategory;
 
     @Builder(access = AccessLevel.PRIVATE)
     private PostUpdateRequest(
             final String title,
             final String content,
-            final Category category
+            final MainCategory mainCategory,
+            final SubCategory subCategory
     ) {
         this.title = title;
         this.content = content;
-        this.category = category;
+        this.mainCategory = mainCategory;
+        this.subCategory = subCategory;
     }
 
     public static PostUpdateRequest of(
             final String title,
             final String content,
-            final Category category
+            final MainCategory mainCategory,
+            final SubCategory subCategory
     ) {
         return PostUpdateRequest.builder()
                 .title(title)
                 .content(content)
-                .category(category)
+                .mainCategory(mainCategory)
+                .subCategory(subCategory)
                 .build();
     }
 } 

--- a/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostResponse.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostResponse.java
@@ -1,6 +1,7 @@
 package com.pyeon.domain.post.dto.response;
 
-import com.pyeon.domain.post.domain.Category;
+import com.pyeon.domain.post.domain.enums.MainCategory;
+import com.pyeon.domain.post.domain.enums.SubCategory;
 import com.pyeon.domain.post.domain.Post;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,7 +23,8 @@ public class PostResponse {
     private long likeCount;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
-    private Category category;
+    private MainCategory mainCategory;
+    private SubCategory subCategory;
     private List<CommentResponse> comments;
     private boolean hasLiked;
 
@@ -37,7 +39,8 @@ public class PostResponse {
             long likeCount,
             LocalDateTime createdAt,
             LocalDateTime modifiedAt,
-            Category category,
+            MainCategory mainCategory,
+            SubCategory subCategory,
             List<CommentResponse> comments,
             boolean hasLiked
     ) {
@@ -50,7 +53,8 @@ public class PostResponse {
         this.likeCount = likeCount;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
-        this.category = category;
+        this.mainCategory = mainCategory;
+        this.subCategory = subCategory;
         this.comments = comments;
         this.hasLiked = hasLiked;
     }
@@ -66,7 +70,8 @@ public class PostResponse {
                 .likeCount(post.getLikeCount())
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
-                .category(post.getCategory())
+                .mainCategory(post.getMainCategory())
+                .subCategory(post.getSubCategory())
                 .comments(post.getComments().stream().map(CommentResponse::from).toList())
                 .hasLiked(hasLiked)
                 .build();

--- a/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostSummaryResponse.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/dto/response/PostSummaryResponse.java
@@ -1,5 +1,7 @@
 package com.pyeon.domain.post.dto.response;
 
+import com.pyeon.domain.post.domain.enums.MainCategory;
+import com.pyeon.domain.post.domain.enums.SubCategory;
 import com.pyeon.domain.post.domain.Post;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,6 +18,9 @@ public class PostSummaryResponse {
     private String memberNickname;
     private long viewCount;
     private long likeCount;
+    private long commentCount;
+    private MainCategory mainCategory;
+    private SubCategory subCategory;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -25,6 +30,9 @@ public class PostSummaryResponse {
             String memberNickname,
             long viewCount,
             long likeCount,
+            long commentCount,
+            MainCategory mainCategory,
+            SubCategory subCategory,
             LocalDateTime createdAt,
             LocalDateTime modifiedAt
     ) {
@@ -33,6 +41,9 @@ public class PostSummaryResponse {
         this.memberNickname = memberNickname;
         this.viewCount = viewCount;
         this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.mainCategory = mainCategory;
+        this.subCategory = subCategory;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }
@@ -44,6 +55,9 @@ public class PostSummaryResponse {
                 .memberNickname(post.getMember().getNickname())
                 .viewCount(post.getViewCount())
                 .likeCount(post.getLikeCount())
+                .commentCount(post.getComments().size())
+                .mainCategory(post.getMainCategory())
+                .subCategory(post.getSubCategory())
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
                 .build();

--- a/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
@@ -48,10 +48,10 @@ public class PostController {
 
     @GetMapping
     public ResponseEntity<Page<PostSummaryResponse>> getPosts(
-            @RequestParam(required = false) MainCategory mainCategory,
-            @RequestParam(required = false) SubCategory subCategory,
-            @RequestParam(required = false) String searchText,
-            @RequestParam(defaultValue = "false") boolean onlyPopular,
+            @RequestParam(name = "mainCategory", required = false) MainCategory mainCategory,
+            @RequestParam(name = "subCategory", required = false) SubCategory subCategory,
+            @RequestParam(name = "searchText", required = false) String searchText,
+            @RequestParam(name = "onlyPopular", defaultValue = "false") boolean onlyPopular,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(postService.getPostsSummary(mainCategory, subCategory, searchText, onlyPopular, pageable));
@@ -100,7 +100,7 @@ public class PostController {
     @GetMapping("/members/{memberId}")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Page<PostSummaryResponse>> getMemberPosts(
-            @PathVariable Long memberId,
+            @PathVariable(name = "memberId") Long memberId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(postService.getPostsSummaryByMemberId(memberId, pageable));

--- a/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
@@ -1,10 +1,12 @@
 package com.pyeon.domain.post.presentation;
 
 import com.pyeon.domain.auth.domain.UserPrincipal;
-import com.pyeon.domain.post.domain.Category;
+import com.pyeon.domain.post.domain.enums.MainCategory;
+import com.pyeon.domain.post.domain.enums.SubCategory;
 import com.pyeon.domain.post.dto.request.PostCreateRequest;
 import com.pyeon.domain.post.dto.request.PostUpdateRequest;
 import com.pyeon.domain.post.dto.response.PostResponse;
+import com.pyeon.domain.post.dto.response.PostSummaryResponse;
 import com.pyeon.domain.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -45,13 +47,14 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<PostResponse>> getPosts(
-            @RequestParam(required = false) Category category,
+    public ResponseEntity<Page<PostSummaryResponse>> getPosts(
+            @RequestParam(required = false) MainCategory mainCategory,
+            @RequestParam(required = false) SubCategory subCategory,
             @RequestParam(required = false) String searchText,
             @RequestParam(defaultValue = "false") boolean onlyPopular,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return ResponseEntity.ok(postService.getPosts(category, searchText, onlyPopular, pageable));
+        return ResponseEntity.ok(postService.getPostsSummary(mainCategory, subCategory, searchText, onlyPopular, pageable));
     }
 
     @PutMapping("/{postId}")
@@ -87,19 +90,19 @@ public class PostController {
     
     @GetMapping("/my")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<Page<PostResponse>> getMyPosts(
+    public ResponseEntity<Page<PostSummaryResponse>> getMyPosts(
             @AuthenticationPrincipal UserPrincipal principal,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return ResponseEntity.ok(postService.getPostsByMemberId(principal.getId(), pageable));
+        return ResponseEntity.ok(postService.getPostsSummaryByMemberId(principal.getId(), pageable));
     }
 
     @GetMapping("/members/{memberId}")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<Page<PostResponse>> getMemberPosts(
+    public ResponseEntity<Page<PostSummaryResponse>> getMemberPosts(
             @PathVariable Long memberId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return ResponseEntity.ok(postService.getPostsByMemberId(memberId, pageable));
+        return ResponseEntity.ok(postService.getPostsSummaryByMemberId(memberId, pageable));
     }
 }

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
@@ -1,9 +1,11 @@
 package com.pyeon.domain.post.service;
 
-import com.pyeon.domain.post.domain.Category;
+import com.pyeon.domain.post.domain.enums.MainCategory;
+import com.pyeon.domain.post.domain.enums.SubCategory;
 import com.pyeon.domain.post.dto.request.PostCreateRequest;
 import com.pyeon.domain.post.dto.request.PostUpdateRequest;
 import com.pyeon.domain.post.dto.response.PostResponse;
+import com.pyeon.domain.post.dto.response.PostSummaryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,13 +15,24 @@ public interface PostService {
     PostResponse getPost(Long id, Long memberId);
 
     public Page<PostResponse> getPosts(
-            Category category,
+            MainCategory mainCategory,
+            SubCategory subCategory,
+            String searchText,
+            boolean onlyPopular,
+            Pageable pageable
+    );
+
+    public Page<PostSummaryResponse> getPostsSummary(
+            MainCategory mainCategory,
+            SubCategory subCategory,
             String searchText,
             boolean onlyPopular,
             Pageable pageable
     );
 
     Page<PostResponse> getPostsByMemberId(Long memberId, Pageable pageable);
+    
+    Page<PostSummaryResponse> getPostsSummaryByMemberId(Long memberId, Pageable pageable);
     
     void updatePost(Long postId, PostUpdateRequest request, Long memberId);
     


### PR DESCRIPTION
## 발생한 문제 
  - 게시글 목록 조회 시 불필요한 상세 내용과 댓글 목록 전체를 가져오는 문제 발생
  - 목록 화면에서는 게시글 요약 정보와 댓글 수만 필요함

## 주요 변경 사항
   - PostSummaryResponse 클래스 수정
     * 댓글 수(commentCount) 필드 추가
     * 게시글 상세 내용(content)과 댓글 목록은 제외하고 필요한 요약 정보만 포함
   
   - PostController 수정
     * 게시글 목록 조회 타입을 PostResponse에서 PostSummaryResponse로 변경