### PR TITLE
refact: comment 코드 컨벤션 일관화 작업 및 검증 로직 수정

### DIFF
--- a/pyeon/src/main/java/com/pyeon/PyeonApplication.java
+++ b/pyeon/src/main/java/com/pyeon/PyeonApplication.java
@@ -2,8 +2,10 @@ package com.pyeon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PyeonApplication {
 
 	public static void main(String[] args) {

--- a/pyeon/src/main/java/com/pyeon/domain/auth/checker/CommentAuthChecker.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/checker/CommentAuthChecker.java
@@ -1,0 +1,28 @@
+package com.pyeon.domain.auth.checker;
+
+import com.pyeon.domain.auth.domain.UserPrincipal;
+import com.pyeon.domain.post.dao.CommentRepository;
+import com.pyeon.domain.post.domain.Comment;
+import com.pyeon.global.exception.CustomException;
+import com.pyeon.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CommentAuthChecker {
+    private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public boolean canModify(Long commentId, UserPrincipal principal) {
+        if (principal == null) {
+            return false;
+        }
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        return comment.getMember().getId().equals(principal.getId());
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/member/domain/Member.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/domain/Member.java
@@ -2,7 +2,7 @@ package com.pyeon.domain.member.domain;
 
 import com.pyeon.domain.auth.domain.Authority;
 import com.pyeon.domain.post.domain.Post;
-import com.pyeon.global.entity.BaseTimeEntity;
+import com.pyeon.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/pyeon/src/main/java/com/pyeon/domain/post/domain/Comment.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/domain/Comment.java
@@ -1,7 +1,7 @@
 package com.pyeon.domain.post.domain;
 
 import com.pyeon.domain.member.domain.Member;
-import com.pyeon.global.entity.BaseTimeEntity;
+import com.pyeon.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,7 +16,6 @@ import org.hibernate.annotations.Where;
 @Where(clause = "is_active = true")
 @SQLDelete(sql = "UPDATE comment SET is_active = false WHERE id = ?")
 public class Comment extends BaseTimeEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,22 +24,18 @@ public class Comment extends BaseTimeEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
+    @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
     @Column(nullable = false)
     private boolean isActive;
 
     @Builder
-    public Comment(
-            String content,
-            Member member,
-            Post post
-    ) {
+    public Comment(String content, Member member, Post post) {
         this.content = content;
         this.member = member;
         this.post = post;
@@ -51,8 +46,8 @@ public class Comment extends BaseTimeEntity {
         this.content = content;
     }
 
-    public boolean isAuthor(String email) {
-        return member.getEmail().equals(email);
+    public boolean isWriter(Member member) {
+        return this.member.getId().equals(member.getId());
     }
 
     public void delete() {

--- a/pyeon/src/main/java/com/pyeon/domain/post/domain/Post.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/domain/Post.java
@@ -3,7 +3,7 @@ package com.pyeon.domain.post.domain;
 import com.pyeon.domain.member.domain.Member;
 import com.pyeon.domain.post.domain.enums.MainCategory;
 import com.pyeon.domain.post.domain.enums.SubCategory;
-import com.pyeon.global.entity.BaseTimeEntity;
+import com.pyeon.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/pyeon/src/main/java/com/pyeon/domain/post/presentation/CommentController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/presentation/CommentController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,7 +19,7 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('USER') and @postAuthChecker.canWrite(principal)")
     public ResponseEntity<Long> createComment(
             @PathVariable(name = "postId") Long postId,
             @RequestBody @Valid CommentCreateRequest request,
@@ -29,10 +30,10 @@ public class CommentController {
     }
 
     @PutMapping("/{commentId}")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('USER') and @commentAuthChecker.canModify(#id, principal)")
     public ResponseEntity<Void> updateComment(
             @PathVariable(name = "postId") Long postId,
-            @PathVariable(name = "commentId") Long commentId,
+            @PathVariable(name = "commentId") @P("id") Long commentId,
             @RequestBody @Valid CommentCreateRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
@@ -41,10 +42,10 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('USER') and @commentAuthChecker.canModify(#id, principal)")
     public ResponseEntity<Void> deleteComment(
             @PathVariable(name = "postId") Long postId,
-            @PathVariable(name = "commentId") Long commentId,
+            @PathVariable(name = "commentId") @P("id") Long commentId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         commentService.deleteComment(commentId, principal.getId());

--- a/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/presentation/PostController.java
@@ -8,6 +8,8 @@ import com.pyeon.domain.post.dto.request.PostUpdateRequest;
 import com.pyeon.domain.post.dto.response.PostResponse;
 import com.pyeon.domain.post.dto.response.PostSummaryResponse;
 import com.pyeon.domain.post.service.PostService;
+import com.pyeon.global.exception.CustomException;
+import com.pyeon.global.exception.ErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -58,9 +61,9 @@ public class PostController {
     }
 
     @PutMapping("/{postId}")
-    @PreAuthorize("@postAuthChecker.canModify(#postId, principal)")
+    @PreAuthorize("@postAuthChecker.canModify(#id, principal)")
     public ResponseEntity<Void> updatePost(
-            @PathVariable(name = "postId") Long postId,
+            @PathVariable(name = "postId") @P("id") Long postId,
             @RequestBody @Valid PostUpdateRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
@@ -69,9 +72,9 @@ public class PostController {
     }
 
     @DeleteMapping("/{postId}")
-    @PreAuthorize("@postAuthChecker.canModify(#postId, principal)")
+    @PreAuthorize("@postAuthChecker.canModify(#id, principal)")
     public ResponseEntity<Void> deletePost(
-            @PathVariable(name = "postId") Long postId,
+            @PathVariable(name = "postId") @P("id") Long postId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         postService.deletePost(postId, principal.getId());
@@ -87,7 +90,7 @@ public class PostController {
         postService.likePost(postId, principal.getId());
         return ResponseEntity.ok().build();
     }
-    
+
     @GetMapping("/my")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Page<PostSummaryResponse>> getMyPosts(

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/CommentServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/CommentServiceImpl.java
@@ -40,8 +40,9 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public void updateComment(Long commentId, CommentCreateRequest request, Long memberId) {
         Comment comment = findCommentById(commentId);
+        Member member = findMemberById(memberId);
         
-        if (!comment.isAuthor(findMemberById(memberId).getEmail())) {
+        if (!comment.isWriter(member)) {
             throw new CustomException(ErrorCode.NOT_COMMENT_AUTHOR);
         }
         
@@ -54,13 +55,16 @@ public class CommentServiceImpl implements CommentService {
         Comment comment = findCommentById(commentId);
         Member member = findMemberById(memberId);
         
-        if (!comment.isAuthor(member.getEmail()) && !member.isAdmin()) {
+        if (!comment.isWriter(member)) {
             throw new CustomException(ErrorCode.NOT_COMMENT_AUTHOR);
         }
         
-        comment.delete();
+        commentRepository.delete(comment);
     }
 
+    /**
+     * Private 함수들
+     */
     private Comment findCommentById(Long id) {
         return commentRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/PostService.java
@@ -39,4 +39,11 @@ public interface PostService {
     void deletePost(Long postId, Long memberId);
     
     void likePost(Long postId, Long memberId);
+
+    /**
+     * 게시글 조회수를 증가시킵니다.
+     * 
+     * @param postId 조회수를 증가시킬 게시글 ID
+     */
+    void incrementViewCount(Long postId);
 }

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/PostServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/PostServiceImpl.java
@@ -55,13 +55,13 @@ public class PostServiceImpl implements PostService {
     public PostResponse getPost(Long id, Long memberId) {
         Post post = findPostById(id);
         post.incrementViewCount();
-        
+
         boolean hasLiked = false;
-        
+
         if (memberId != null) {
             hasLiked = hasLiked(post.getId(), memberId);
         }
-        
+
         return PostResponse.from(post, hasLiked);
     }
 
@@ -112,7 +112,7 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public void deletePost(Long postId, Long memberId) {
         Post post = findPostById(postId);
-        
+
         try {
             String key = LIKE_KEY_PREFIX + postId;
             redisTemplate.delete(key);
@@ -200,6 +200,13 @@ public class PostServiceImpl implements PostService {
         
         return postRepository.findAll(spec, pageable)
                 .map(PostSummaryResponse::from);
+    }
+
+    @Transactional
+    public void incrementViewCount(Long postId) {
+        Post post = findPostById(postId);
+        post.incrementViewCount();
+        postRepository.save(post);
     }
 
     /**

--- a/pyeon/src/main/java/com/pyeon/global/common/BaseTimeEntity.java
+++ b/pyeon/src/main/java/com/pyeon/global/common/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.pyeon.global.entity;
+package com.pyeon.global.common;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;


### PR DESCRIPTION
# 변경 사항

## PostAuthChecker 관련 이슈 해결
- @PreAuthorize에서 변수 바인딩 문제 발생
- @P 어노테이션을 사용하여 해결

## Comment 엔티티 코드 컨벤션 통일
- Post 엔티티와 동일한 패턴 적용

## 고민한 점
- 댓글 조회는 별도 API로 분리하지 않음
- 게시글 조회 시 댓글을 포함하여 응답하는 것이 UX적으로 더 자연스럽다고 판단
- 실제 사용자들이 댓글만 따로 보는 경우가 거의 없다는 점 고려
- 불필요한 API 호출을 줄이고 단순한 구조 유지

