### PR TITLE
refact: 퍼사드 패턴 도입을 통한 결합도 감소 적용

### DIFF
--- a/pyeon/src/main/java/com/pyeon/domain/member/facade/MemberFacade.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/facade/MemberFacade.java
@@ -1,0 +1,26 @@
+package com.pyeon.domain.member.facade;
+
+import com.pyeon.domain.member.domain.Member;
+
+/**
+ * Member 도메인에 대한 파사드 인터페이스
+ * 다른 도메인에서 Member 도메인에 접근할 때 사용하는 인터페이스입니다.
+ */
+public interface MemberFacade {
+    /**
+     * ID로 회원을 조회합니다.
+     * 
+     * @param id 회원 ID
+     * @return 조회된 회원 엔티티
+     * @throws com.pyeon.global.exception.CustomException 회원이 존재하지 않을 경우
+     */
+    Member getMemberById(Long id);
+    
+    /**
+     * 회원의 존재 여부를 확인합니다.
+     * 
+     * @param id 회원 ID
+     * @return 회원 존재 여부
+     */
+    boolean isMemberExists(Long id);
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/member/facade/MemberFacadeImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/facade/MemberFacadeImpl.java
@@ -1,0 +1,28 @@
+package com.pyeon.domain.member.facade;
+
+import com.pyeon.domain.member.dao.MemberRepository;
+import com.pyeon.domain.member.domain.Member;
+import com.pyeon.global.exception.CustomException;
+import com.pyeon.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Member 도메인에 대한 파사드 구현체
+ */
+@Component
+@RequiredArgsConstructor
+public class MemberFacadeImpl implements MemberFacade {
+    private final MemberRepository memberRepository;
+    
+    @Override
+    public Member getMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+    
+    @Override
+    public boolean isMemberExists(Long id) {
+        return memberRepository.existsById(id);
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/member/presentation/MemberController.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/presentation/MemberController.java
@@ -34,7 +34,7 @@ public class MemberController {
     }
 
     @PutMapping("/me")
-    @PreAuthorize("@memberAuthChecker.isOwner(#principal.id, principal)")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Void> updateMyInfo(
             @RequestBody @Valid MemberUpdateRequest request,
             @AuthenticationPrincipal UserPrincipal principal
@@ -44,7 +44,7 @@ public class MemberController {
     }
 
     @DeleteMapping("/me")
-    @PreAuthorize("@memberAuthChecker.isOwner(#principal.id, principal)")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Void> deleteMyAccount(
             @AuthenticationPrincipal UserPrincipal principal
     ) {

--- a/pyeon/src/main/java/com/pyeon/domain/post/facade/CommentFacade.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/facade/CommentFacade.java
@@ -1,0 +1,26 @@
+package com.pyeon.domain.post.facade;
+
+import com.pyeon.domain.post.domain.Comment;
+
+/**
+ * Comment 도메인에 대한 파사드 인터페이스
+ * 다른 도메인에서 Comment 도메인에 접근할 때 사용하는 인터페이스입니다.
+ */
+public interface CommentFacade {
+    /**
+     * ID로 댓글을 조회합니다.
+     * 
+     * @param id 댓글 ID
+     * @return 조회된 댓글 엔티티
+     * @throws com.pyeon.global.exception.CustomException 댓글이 존재하지 않을 경우
+     */
+    Comment getCommentById(Long id);
+    
+    /**
+     * 댓글의 존재 여부를 확인합니다.
+     * 
+     * @param id 댓글 ID
+     * @return 댓글 존재 여부
+     */
+    boolean isCommentExists(Long id);
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/post/facade/CommentFacadeImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/facade/CommentFacadeImpl.java
@@ -1,0 +1,28 @@
+package com.pyeon.domain.post.facade;
+
+import com.pyeon.domain.post.dao.CommentRepository;
+import com.pyeon.domain.post.domain.Comment;
+import com.pyeon.global.exception.CustomException;
+import com.pyeon.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Comment 도메인에 대한 파사드 구현체
+ */
+@Component
+@RequiredArgsConstructor
+public class CommentFacadeImpl implements CommentFacade {
+    private final CommentRepository commentRepository;
+    
+    @Override
+    public Comment getCommentById(Long id) {
+        return commentRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+    }
+    
+    @Override
+    public boolean isCommentExists(Long id) {
+        return commentRepository.existsById(id);
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/post/facade/PostFacade.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/facade/PostFacade.java
@@ -1,0 +1,33 @@
+package com.pyeon.domain.post.facade;
+
+import com.pyeon.domain.post.domain.Post;
+
+/**
+ * Post 도메인에 대한 파사드 인터페이스
+ * 다른 도메인에서 Post 도메인에 접근할 때 사용하는 인터페이스입니다.
+ */
+public interface PostFacade {
+    /**
+     * ID로 게시글을 조회합니다.
+     * 
+     * @param id 게시글 ID
+     * @return 조회된 게시글 엔티티
+     * @throws com.pyeon.global.exception.CustomException 게시글이 존재하지 않을 경우
+     */
+    Post getPostById(Long id);
+    
+    /**
+     * 게시글의 존재 여부를 확인합니다.
+     * 
+     * @param id 게시글 ID
+     * @return 게시글 존재 여부
+     */
+    boolean isPostExists(Long id);
+    
+    /**
+     * 게시글의 조회수를 증가시킵니다.
+     * 
+     * @param id 게시글 ID
+     */
+    void incrementViewCount(Long id);
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/post/facade/PostFacadeImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/facade/PostFacadeImpl.java
@@ -1,0 +1,37 @@
+package com.pyeon.domain.post.facade;
+
+import com.pyeon.domain.post.dao.PostRepository;
+import com.pyeon.domain.post.domain.Post;
+import com.pyeon.global.exception.CustomException;
+import com.pyeon.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Post 도메인에 대한 파사드 구현체
+ */
+@Component
+@RequiredArgsConstructor
+public class PostFacadeImpl implements PostFacade {
+    private final PostRepository postRepository;
+    
+    @Override
+    public Post getPostById(Long id) {
+        return postRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    }
+    
+    @Override
+    public boolean isPostExists(Long id) {
+        return postRepository.existsById(id);
+    }
+    
+    @Override
+    @Transactional
+    public void incrementViewCount(Long id) {
+        Post post = getPostById(id);
+        post.incrementViewCount();
+        postRepository.save(post);
+    }
+} 

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/CommentServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/CommentServiceImpl.java
@@ -1,12 +1,12 @@
 package com.pyeon.domain.post.service;
 
-import com.pyeon.domain.member.dao.MemberRepository;
 import com.pyeon.domain.member.domain.Member;
+import com.pyeon.domain.member.facade.MemberFacade;
 import com.pyeon.domain.post.dao.CommentRepository;
-import com.pyeon.domain.post.dao.PostRepository;
 import com.pyeon.domain.post.domain.Comment;
 import com.pyeon.domain.post.domain.Post;
 import com.pyeon.domain.post.dto.request.CommentCreateRequest;
+import com.pyeon.domain.post.facade.PostFacade;
 import com.pyeon.global.exception.CustomException;
 import com.pyeon.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -18,14 +18,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CommentServiceImpl implements CommentService {
     private final CommentRepository commentRepository;
-    private final PostRepository postRepository;
-    private final MemberRepository memberRepository;
+    private final PostFacade postFacade;
+    private final MemberFacade memberFacade;
 
     @Override
     @Transactional
     public Long createComment(Long postId, CommentCreateRequest request, Long memberId) {
-        Post post = findPostById(postId);
-        Member member = findMemberById(memberId);
+        Post post = postFacade.getPostById(postId);
+        Member member = memberFacade.getMemberById(memberId);
 
         Comment comment = Comment.builder()
                 .content(request.getContent())
@@ -40,7 +40,7 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public void updateComment(Long commentId, CommentCreateRequest request, Long memberId) {
         Comment comment = findCommentById(commentId);
-        Member member = findMemberById(memberId);
+        Member member = memberFacade.getMemberById(memberId);
         
         if (!comment.isWriter(member)) {
             throw new CustomException(ErrorCode.NOT_COMMENT_AUTHOR);
@@ -53,7 +53,7 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public void deleteComment(Long commentId, Long memberId) {
         Comment comment = findCommentById(commentId);
-        Member member = findMemberById(memberId);
+        Member member = memberFacade.getMemberById(memberId);
         
         if (!comment.isWriter(member)) {
             throw new CustomException(ErrorCode.NOT_COMMENT_AUTHOR);
@@ -68,15 +68,5 @@ public class CommentServiceImpl implements CommentService {
     private Comment findCommentById(Long id) {
         return commentRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
-    }
-
-    private Post findPostById(Long id) {
-        return postRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-    }
-
-    private Member findMemberById(Long id) {
-        return memberRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 } 

--- a/pyeon/src/main/java/com/pyeon/domain/post/service/PostServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/PostServiceImpl.java
@@ -1,7 +1,7 @@
 package com.pyeon.domain.post.service;
 
-import com.pyeon.domain.member.dao.MemberRepository;
 import com.pyeon.domain.member.domain.Member;
+import com.pyeon.domain.member.facade.MemberFacade;
 import com.pyeon.domain.post.dao.PostRepository;
 import com.pyeon.domain.post.domain.enums.MainCategory;
 import com.pyeon.domain.post.domain.enums.SubCategory;
@@ -31,7 +31,7 @@ import static com.pyeon.domain.post.dao.PostSpecification.containsText;
 @Transactional(readOnly = true)
 public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
-    private final MemberRepository memberRepository;
+    private final MemberFacade memberFacade;
     private final StringRedisTemplate redisTemplate;
 
     private static final String LIKE_KEY_PREFIX = "post:like:";
@@ -39,7 +39,7 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional
     public Long createPost(PostCreateRequest request, Long memberId) {
-        Member member = findMemberById(memberId);
+        Member member = memberFacade.getMemberById(memberId);
         Post post = Post.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
@@ -150,7 +150,7 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional(readOnly = true)
     public Page<PostResponse> getPostsByMemberId(Long memberId, Pageable pageable) {
-        Member member = findMemberById(memberId);
+        Member member = memberFacade.getMemberById(memberId);
         Specification<Post> spec = Specification.where((root, query, builder) ->
             builder.equal(root.get("member"), member)
         );
@@ -193,7 +193,7 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional(readOnly = true)
     public Page<PostSummaryResponse> getPostsSummaryByMemberId(Long memberId, Pageable pageable) {
-        Member member = findMemberById(memberId);
+        Member member = memberFacade.getMemberById(memberId);
         Specification<Post> spec = Specification.where((root, query, builder) ->
             builder.equal(root.get("member"), member)
         );
@@ -227,10 +227,5 @@ public class PostServiceImpl implements PostService {
     private Post findPostById(Long id) {
         return postRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-    }
-
-    private Member findMemberById(Long id) {
-        return memberRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/pyeon/src/main/java/com/pyeon/global/config/SecurityConfig.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/SecurityConfig.java
@@ -53,12 +53,20 @@ public class SecurityConfig {
                             "/oauth2/**",
                             "/api/images/**"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/posts").permitAll()
                         .requestMatchers("/api/posts/{postId}").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/posts/**").hasRole("USER")
                         .requestMatchers(HttpMethod.PUT, "/api/posts/**").hasRole("USER")
                         .requestMatchers(HttpMethod.DELETE, "/api/posts/**").hasRole("USER")
+                        .requestMatchers(HttpMethod.POST, "/api/posts/*/comments/**").hasRole("USER")
+                        .requestMatchers(HttpMethod.PUT, "/api/posts/*/comments/**").hasRole("USER")
+                        .requestMatchers(HttpMethod.DELETE, "/api/posts/*/comments/**").hasRole("USER")
+                        .requestMatchers("/api/members/me").hasRole("USER")
+                        .requestMatchers(HttpMethod.GET, "/api/members/{memberId}").hasRole("USER")
+                        .requestMatchers(HttpMethod.PUT, "/api/members/me").hasRole("USER")
+                        .requestMatchers(HttpMethod.DELETE, "/api/members/me").hasRole("USER")
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
# 파사드 패턴 적용을 통한 도메인 간 결합도 개선 과정

## 1. 문제 인식
- 서비스 계층에서 다른 도메인의 Repository를 직접 의존하고 있음
- PostServiceImpl이 MemberRepository를 직접 사용
- CommentServiceImpl이 MemberRepository와 PostRepository를 직접 사용
- 이로 인해 도메인 간 결합도가 높아지고 단일 책임 원칙(SRP)과 의존성 역전 원칙(DIP) 위반

## 2. 해결 방안 검토
- 파사드 패턴 적용
  - 각 도메인에 대한 파사드를 만들어 다른 도메인에서 접근할 수 있는 인터페이스 제공
- 이벤트 기반 아키텍처
  - 도메인 간 통신을 이벤트를 통해 수행하여 결합도 낮춤
- ID 참조 방식
  - 엔티티 간 직접 참조 대신 ID 참조 방식으로 변경
  - 근데 이 방식은 성능 이슈(N+1)하고 코드가 너무 복잡해짐
  
**프로젝트 규모와 현실적인 적용 가능성을 고려하여 파사드 패턴을 선택**

## 3. 파사드 패턴 적용 과정
- 각 도메인 내에 facade 패키지 추가
- 각 도메인에 대한 파사드 인터페이스 정의 (MemberFacade, PostFacade, CommentFacade)
- 각 파사드 구현체에서 해당 도메인의 Repository를 사용하여 기능 구현
- 서비스 계층에서 다른 도메인의 Repository 대신 파사드 사용하도록 리팩토링
- 각 서비스 클래스에서 다른 도메인의 엔티티를 조회하는 private 메서드 제거