### PR TITLE
feat: 스프링 액츄에이터 추가

### DIFF
--- a/pyeon/build.gradle
+++ b/pyeon/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 

--- a/pyeon/src/main/java/com/pyeon/global/config/SecurityConfig.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/SecurityConfig.java
@@ -51,7 +51,9 @@ public class SecurityConfig {
                             "/favicon.ico",
                             "/api/auth/**",
                             "/oauth2/**",
-                            "/api/images/**"
+                            "/api/images/**",
+                            "/actuator/health",
+                            "/actuator/info"
                         ).permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/pyeon/src/main/resources/application.yml
+++ b/pyeon/src/main/resources/application.yml
@@ -1,6 +1,23 @@
 spring:
   profiles:
     active: prod
+
+# Actuator 공통 설정 추가
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always
+  health:
+    diskspace:
+      enabled: true
+    db:
+      enabled: true
+    redis:
+      enabled: true
 ---
 spring:
   config:


### PR DESCRIPTION
# Spring Boot Actuator 추가

## 개요
블루-그린 배포 과정에서 필요한 헬스체크 기능을 위해 Spring Boot Actuator를 추가

## 변경 사항
- Spring Boot Actuator 의존성 추가
- Actuator 설정 추가 (헬스체크, 정보 엔드포인트 활성화)
- Security 설정에서 Actuator 엔드포인트 접근 허용
- 블루-그린 배포 스크립트의 헬스체크 정상 작동
- 애플리케이션 상태 모니터링 기능 추가
- 배포 안정성 향상
