### PR TITLE
feat: Grafana 및 Prometheus 경량 수준 설정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -130,7 +130,7 @@ jobs:
           username: ${{ secrets.PROD_USERNAME }}
           key: ${{ secrets.PROD_SSH_KEY }}
           port: 22
-          source: "pyeon/deploy-blue-green.sh,pyeon/docker-compose.prod.yml,pyeon/docker-compose.blue.yml,pyeon/docker-compose.green.yml,pyeon/nginx.conf"
+          source: "pyeon/deploy-blue-green.sh,pyeon/docker-compose.prod.yml,pyeon/docker-compose.blue.yml,pyeon/docker-compose.green.yml,pyeon/nginx.conf,pyeon/prometheus.yml"
           target: "/tmp"
           strip_components: 1
 
@@ -144,8 +144,13 @@ jobs:
           debug: true
           script: |
             mkdir -p /app
-            cp /tmp/deploy-blue-green.sh /tmp/docker-compose.prod.yml /tmp/docker-compose.blue.yml /tmp/docker-compose.green.yml /tmp/nginx.conf /app/
+            cp /tmp/deploy-blue-green.sh /tmp/docker-compose.prod.yml /tmp/docker-compose.blue.yml /tmp/docker-compose.green.yml /tmp/nginx.conf /tmp/prometheus.yml /app/
             chmod +x /app/deploy-blue-green.sh
+
+            # Prometheus 접근 제한을 위한 .htpasswd 파일 생성
+            apt-get update && apt-get install -y apache2-utils
+            mkdir -p /etc/nginx
+            htpasswd -bc /etc/nginx/.htpasswd.prometheus admin ${{ secrets.PROMETHEUS_PASSWORD || 'admin123' }}
 
       - name: Create .env file on server
         uses: appleboy/ssh-action@master
@@ -196,6 +201,9 @@ jobs:
             # Domain
             PROD_DOMAIN=api.pyeondongbu.com
             PROD_FRONTEND_URL=${{ secrets.PROD_FRONTEND_URL }}
+
+            # Grafana
+            GRAFANA_ADMIN_PASSWORD=${{ secrets.GRAFANA_ADMIN_PASSWORD }}
             EOL
             chmod 600 .env
 
@@ -260,18 +268,3 @@ jobs:
               echo "서비스 배포 실패"
               exit 1
             fi
-
-      - name: Notify deployment result
-        if: always()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: deployments
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_TITLE: 배포 결과
-          SLACK_MESSAGE: |
-            환경: Production
-            상태: ${{ job.status }}
-            커밋: ${{ github.event.head_commit.message }}
-            작성자: ${{ github.event.head_commit.author.name }}
-            시간: ${{ github.event.head_commit.timestamp }}

--- a/pyeon/deploy-blue-green.sh
+++ b/pyeon/deploy-blue-green.sh
@@ -149,6 +149,18 @@ else
   docker-compose -f docker-compose.prod.yml up -d nginx
 fi
 
+# 모니터링 서비스 시작 또는 재시작
+echo "모니터링 서비스 확인 중..."
+PROMETHEUS_RUNNING=$(docker ps --filter "name=app-prometheus-1" --format "{{.Names}}" | grep -q "app-prometheus-1" && echo "yes" || echo "no")
+GRAFANA_RUNNING=$(docker ps --filter "name=app-grafana-1" --format "{{.Names}}" | grep -q "app-grafana-1" && echo "yes" || echo "no")
+
+if [ "$PROMETHEUS_RUNNING" == "no" ] || [ "$GRAFANA_RUNNING" == "no" ]; then
+  echo "모니터링 서비스 시작 중..."
+  docker-compose -f docker-compose.prod.yml up -d prometheus grafana
+else
+  echo "모니터링 서비스가 이미 실행 중입니다."
+fi
+
 # Nginx 재시작 후 상태 확인
 NGINX_STATUS=$(docker inspect --format='{{.State.Status}}' app-nginx-1 2>/dev/null || echo "not_found")
 if [ "$NGINX_STATUS" != "running" ]; then

--- a/pyeon/deploy-blue-green.sh
+++ b/pyeon/deploy-blue-green.sh
@@ -11,6 +11,15 @@ if [ -f .env ]; then
   export $(grep -v '^#' .env | xargs)
 fi
 
+# 네트워크 존재 여부 확인 및 생성
+NETWORK_EXISTS=$(docker network ls | grep app_app-network || echo "")
+if [ -z "$NETWORK_EXISTS" ]; then
+  echo "app_app-network 네트워크가 존재하지 않습니다. 생성합니다."
+  docker network create app_app-network
+else
+  echo "app_app-network 네트워크가 이미 존재합니다."
+fi
+
 # 기존 단일 배포 컨테이너 확인 및 중지
 OLD_APP_CONTAINER=$(docker ps --filter "name=app-app-1" --format "{{.Names}}" | grep -q "app-app-1" && echo "yes" || echo "no")
 if [ "$OLD_APP_CONTAINER" == "yes" ]; then
@@ -34,6 +43,12 @@ fi
 
 echo "현재 운영 중인 컨테이너: $CURRENT_CONTAINER"
 echo "배포 대상 컨테이너: app-$TARGET_COLOR"
+
+# 배포 전 상태 저장 (롤백을 위해)
+if [ "$CURRENT_CONTAINER" != "NONE" ]; then
+  echo "롤백을 위해 현재 상태 저장"
+  CURRENT_NGINX_CONF=$(cat /app/nginx.conf)
+fi
 
 # 최신 이미지 가져오기
 echo "최신 이미지 가져오는 중..."
@@ -63,6 +78,7 @@ docker-compose -f docker-compose.prod.yml -f docker-compose.$TARGET_COLOR.yml up
 
 # 새 컨테이너가 정상적으로 시작될 때까지 대기
 echo "새 컨테이너 헬스체크 중..."
+HEALTH_CHECK_PASSED=false
 for i in {1..30}; do
   # 컨테이너 상태 확인
   CONTAINER_STATUS=$(docker inspect --format='{{.State.Status}}' app-$TARGET_COLOR 2>/dev/null || echo "not_found")
@@ -75,6 +91,7 @@ for i in {1..30}; do
       echo "새 컨테이너 정상 작동 확인 (상태: $CONTAINER_STATUS, 포트 응답: $PORT_CHECK)"
       # 애플리케이션 시작 시간 고려
       sleep 5
+      HEALTH_CHECK_PASSED=true
       break
     fi
   fi
@@ -83,10 +100,37 @@ for i in {1..30}; do
   sleep 2
   
   if [ $i -eq 30 ]; then
-    echo "새 컨테이너 시작 실패. 배포 중단."
+    echo "새 컨테이너 시작 실패. 배포 중단 및 롤백 시작."
+    # 롤백 로직 - 새 컨테이너 중지
+    docker stop app-$TARGET_COLOR
+    docker rm app-$TARGET_COLOR
+    
+    if [ "$CURRENT_CONTAINER" != "NONE" ]; then
+      echo "이전 상태로 롤백합니다."
+      # 이전 컨테이너가 있었다면 계속 사용
+      echo "롤백 완료. 이전 컨테이너($CURRENT_CONTAINER)를 계속 사용합니다."
+    fi
+    
+    echo "===== 배포 실패, 롤백 완료 ====="
     exit 1
   fi
 done
+
+# 헬스체크 실패 시 롤백
+if [ "$HEALTH_CHECK_PASSED" != "true" ]; then
+  echo "헬스체크 실패. 롤백을 시작합니다."
+  docker stop app-$TARGET_COLOR
+  docker rm app-$TARGET_COLOR
+  
+  if [ "$CURRENT_CONTAINER" != "NONE" ]; then
+    echo "이전 상태로 롤백합니다."
+    # 이전 컨테이너가 있었다면 계속 사용
+    echo "롤백 완료. 이전 컨테이너($CURRENT_CONTAINER)를 계속 사용합니다."
+  fi
+  
+  echo "===== 배포 실패, 롤백 완료 ====="
+  exit 1
+fi
 
 # Nginx 설정 업데이트 (트래픽 전환)
 echo "Nginx 설정 업데이트 중..."
@@ -103,6 +147,26 @@ if docker ps | grep -q app-nginx-1; then
 else
   echo "Nginx 시작 중..."
   docker-compose -f docker-compose.prod.yml up -d nginx
+fi
+
+# Nginx 재시작 후 상태 확인
+NGINX_STATUS=$(docker inspect --format='{{.State.Status}}' app-nginx-1 2>/dev/null || echo "not_found")
+if [ "$NGINX_STATUS" != "running" ]; then
+  echo "Nginx 재시작 실패. 롤백을 시작합니다."
+  
+  # Nginx 설정 롤백
+  if [ "$CURRENT_CONTAINER" != "NONE" ]; then
+    echo "$CURRENT_NGINX_CONF" > /app/nginx.conf
+    docker-compose -f docker-compose.prod.yml up -d nginx
+  fi
+  
+  # 새 컨테이너 중지
+  docker stop app-$TARGET_COLOR
+  docker rm app-$TARGET_COLOR
+  
+  echo "롤백 완료. 이전 컨테이너($CURRENT_CONTAINER)를 계속 사용합니다."
+  echo "===== 배포 실패, 롤백 완료 ====="
+  exit 1
 fi
 
 echo "트래픽이 app-$TARGET_COLOR로 전환되었습니다."
@@ -130,6 +194,7 @@ if [ "$FINAL_CHECK" == "200" ]; then
   echo "서비스가 정상적으로 배포되었습니다. (상태 코드: $FINAL_CHECK)"
 else
   echo "주의: 서비스 상태 확인 실패 (상태 코드: $FINAL_CHECK)"
+  echo "하지만 컨테이너는 정상 실행 중입니다. 모니터링이 필요합니다."
 fi
 
 echo "배포 스크립트 실행 완료" 

--- a/pyeon/docker-compose.blue.yml
+++ b/pyeon/docker-compose.blue.yml
@@ -9,44 +9,101 @@ services:
     ports:
       - "8081:8080"
     environment:
+      # Spring 프로필 설정
       - SPRING_PROFILES_ACTIVE=prod
+
+      # 데이터베이스 설정
+      - SPRING_DATASOURCE_URL=jdbc:mysql://app-db-1:3306/pyeon?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+      - SPRING_DATASOURCE_USERNAME=${PROD_DB_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${PROD_DB_PASSWORD}
+      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.cj.jdbc.Driver
       - PROD_DB_HOST=app-db-1
       - PROD_DB_PORT=3306
       - PROD_DB_NAME=pyeon
       - PROD_DB_USERNAME=${PROD_DB_USERNAME}
       - PROD_DB_PASSWORD=${PROD_DB_PASSWORD}
-      - SPRING_DATASOURCE_URL=jdbc:mysql://app-db-1:3306/pyeon?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
-      - SPRING_DATASOURCE_USERNAME=${PROD_DB_USERNAME}
-      - SPRING_DATASOURCE_PASSWORD=${PROD_DB_PASSWORD}
-      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.cj.jdbc.Driver
+
+      # Redis 설정
       - SPRING_DATA_REDIS_HOST=app-redis-1
       - SPRING_DATA_REDIS_PORT=6379
       - SPRING_DATA_REDIS_PASSWORD=${PROD_REDIS_PASSWORD}
       - PROD_REDIS_HOST=app-redis-1
       - PROD_REDIS_PORT=6379
       - PROD_REDIS_PASSWORD=${PROD_REDIS_PASSWORD}
-      - PROD_SERVER_PORT=8080
+
+      # JWT 설정
       - PROD_JWT_SECRET=${PROD_JWT_SECRET_KEY}
+      - jwt.secret-key=${PROD_JWT_SECRET_KEY}
+      - jwt.access-token-validity=259200000
+      - jwt.refresh-token-validity=604800000
+
+      # 서버 설정
+      - PROD_SERVER_PORT=8080
+      - server.port=8080
+
+      # 도메인 설정
+      - PROD_DOMAIN=api.pyeondongbu.com
+      - PROD_FRONTEND_URL=${PROD_FRONTEND_URL}
+      - app.cookie.domain=api.pyeondongbu.com
+
+      # CORS 설정
+      - PROD_CORS_ORIGIN=${PROD_CORS_ORIGIN}
+      - cors.origin=${PROD_CORS_ORIGIN}
+
+      # OAuth 설정
       - PROD_GOOGLE_CLIENT_ID=${PROD_GOOGLE_CLIENT_ID}
       - PROD_GOOGLE_CLIENT_SECRET=${PROD_GOOGLE_CLIENT_SECRET}
       - PROD_GOOGLE_REDIRECT_URI=${PROD_GOOGLE_REDIRECT_URI}
+      - app.oauth2.authorized-redirect-uri=${PROD_GOOGLE_REDIRECT_URI}
+      - spring.security.oauth2.client.registration.google.client-id=${PROD_GOOGLE_CLIENT_ID}
+      - spring.security.oauth2.client.registration.google.client-secret=${PROD_GOOGLE_CLIENT_SECRET}
+
+      # AWS 설정
       - PROD_AWS_ACCESS_KEY=${PROD_AWS_ACCESS_KEY}
       - PROD_AWS_SECRET_KEY=${PROD_AWS_SECRET_KEY}
       - PROD_AWS_REGION=${PROD_AWS_REGION}
       - PROD_S3_BUCKET=${PROD_S3_BUCKET}
       - PROD_S3_FOLDER=${PROD_S3_FOLDER}
-      - PROD_CORS_ORIGIN=${PROD_CORS_ORIGIN}
-      - PROD_DOMAIN=api.pyeondongbu.com
-      - PROD_FRONTEND_URL=${PROD_FRONTEND_URL}
+      - cloud.aws.credentials.access-key=${PROD_AWS_ACCESS_KEY}
+      - cloud.aws.credentials.secret-key=${PROD_AWS_SECRET_KEY}
+      - cloud.aws.region.static=${PROD_AWS_REGION}
+      - cloud.aws.s3.bucket=${PROD_S3_BUCKET}
+      - cloud.aws.s3.folder=${PROD_S3_FOLDER}
+
+      # 로깅 설정
+      - logging.level.root=INFO
+      - logging.level.com.pyeon=INFO
+      - logging.level.org.springframework.security=DEBUG
+      - logging.file.name=/var/log/pyeon/application.log
     restart: always
     networks:
       - app-network
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 512M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
       retries: 3
       start_period: 30s
+    volumes:
+      - /var/log/pyeon:/var/log/pyeon
 
 networks:
   app-network:

--- a/pyeon/docker-compose.green.yml
+++ b/pyeon/docker-compose.green.yml
@@ -9,44 +9,101 @@ services:
     ports:
       - "8082:8080"
     environment:
+      # Spring 프로필 설정
       - SPRING_PROFILES_ACTIVE=prod
+
+      # 데이터베이스 설정
+      - SPRING_DATASOURCE_URL=jdbc:mysql://app-db-1:3306/pyeon?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+      - SPRING_DATASOURCE_USERNAME=${PROD_DB_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${PROD_DB_PASSWORD}
+      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.cj.jdbc.Driver
       - PROD_DB_HOST=app-db-1
       - PROD_DB_PORT=3306
       - PROD_DB_NAME=pyeon
       - PROD_DB_USERNAME=${PROD_DB_USERNAME}
       - PROD_DB_PASSWORD=${PROD_DB_PASSWORD}
-      - SPRING_DATASOURCE_URL=jdbc:mysql://app-db-1:3306/pyeon?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
-      - SPRING_DATASOURCE_USERNAME=${PROD_DB_USERNAME}
-      - SPRING_DATASOURCE_PASSWORD=${PROD_DB_PASSWORD}
-      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.cj.jdbc.Driver
+
+      # Redis 설정
       - SPRING_DATA_REDIS_HOST=app-redis-1
       - SPRING_DATA_REDIS_PORT=6379
       - SPRING_DATA_REDIS_PASSWORD=${PROD_REDIS_PASSWORD}
       - PROD_REDIS_HOST=app-redis-1
       - PROD_REDIS_PORT=6379
       - PROD_REDIS_PASSWORD=${PROD_REDIS_PASSWORD}
-      - PROD_SERVER_PORT=8080
+
+      # JWT 설정
       - PROD_JWT_SECRET=${PROD_JWT_SECRET_KEY}
+      - jwt.secret-key=${PROD_JWT_SECRET_KEY}
+      - jwt.access-token-validity=259200000
+      - jwt.refresh-token-validity=604800000
+
+      # 서버 설정
+      - PROD_SERVER_PORT=8080
+      - server.port=8080
+
+      # 도메인 설정
+      - PROD_DOMAIN=api.pyeondongbu.com
+      - PROD_FRONTEND_URL=${PROD_FRONTEND_URL}
+      - app.cookie.domain=api.pyeondongbu.com
+
+      # CORS 설정
+      - PROD_CORS_ORIGIN=${PROD_CORS_ORIGIN}
+      - cors.origin=${PROD_CORS_ORIGIN}
+
+      # OAuth 설정
       - PROD_GOOGLE_CLIENT_ID=${PROD_GOOGLE_CLIENT_ID}
       - PROD_GOOGLE_CLIENT_SECRET=${PROD_GOOGLE_CLIENT_SECRET}
       - PROD_GOOGLE_REDIRECT_URI=${PROD_GOOGLE_REDIRECT_URI}
+      - app.oauth2.authorized-redirect-uri=${PROD_GOOGLE_REDIRECT_URI}
+      - spring.security.oauth2.client.registration.google.client-id=${PROD_GOOGLE_CLIENT_ID}
+      - spring.security.oauth2.client.registration.google.client-secret=${PROD_GOOGLE_CLIENT_SECRET}
+
+      # AWS 설정
       - PROD_AWS_ACCESS_KEY=${PROD_AWS_ACCESS_KEY}
       - PROD_AWS_SECRET_KEY=${PROD_AWS_SECRET_KEY}
       - PROD_AWS_REGION=${PROD_AWS_REGION}
       - PROD_S3_BUCKET=${PROD_S3_BUCKET}
       - PROD_S3_FOLDER=${PROD_S3_FOLDER}
-      - PROD_CORS_ORIGIN=${PROD_CORS_ORIGIN}
-      - PROD_DOMAIN=api.pyeondongbu.com
-      - PROD_FRONTEND_URL=${PROD_FRONTEND_URL}
+      - cloud.aws.credentials.access-key=${PROD_AWS_ACCESS_KEY}
+      - cloud.aws.credentials.secret-key=${PROD_AWS_SECRET_KEY}
+      - cloud.aws.region.static=${PROD_AWS_REGION}
+      - cloud.aws.s3.bucket=${PROD_S3_BUCKET}
+      - cloud.aws.s3.folder=${PROD_S3_FOLDER}
+
+      # 로깅 설정
+      - logging.level.root=INFO
+      - logging.level.com.pyeon=INFO
+      - logging.level.org.springframework.security=DEBUG
+      - logging.file.name=/var/log/pyeon/application.log
     restart: always
     networks:
       - app-network
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 512M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
       retries: 3
       start_period: 30s
+    volumes:
+      - /var/log/pyeon:/var/log/pyeon
 
 networks:
   app-network:

--- a/pyeon/docker-compose.prod.yml
+++ b/pyeon/docker-compose.prod.yml
@@ -106,9 +106,66 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: app-prometheus-1
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    restart: always
+    networks:
+      - app-network
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: app-grafana-1
+    volumes:
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    restart: always
+    networks:
+      - app-network
+    depends_on:
+      - prometheus
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
 volumes:
   mysql_data_prod:
   redis_data_prod:
+  prometheus_data:
+  grafana_data:
 
 networks:
   app-network:

--- a/pyeon/docker-compose.prod.yml
+++ b/pyeon/docker-compose.prod.yml
@@ -3,6 +3,7 @@ version: "3.8"
 services:
   nginx:
     image: nginx:latest
+    container_name: app-nginx-1
     ports:
       - "80:80"
       - "443:443"
@@ -12,9 +13,23 @@ services:
     restart: always
     networks:
       - app-network
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   db:
     image: mysql:8.0.26
+    container_name: app-db-1
     expose:
       - "3306"
     environment:
@@ -47,9 +62,23 @@ services:
       start_period: 30s
     networks:
       - app-network
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 512M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "5"
 
   redis:
     image: redis:7.0
+    container_name: app-redis-1
     expose:
       - "6379"
     command: ["redis-server", "--requirepass", "${PROD_REDIS_PASSWORD}"]
@@ -63,6 +92,19 @@ services:
       retries: 5
     networks:
       - app-network
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   mysql_data_prod:
@@ -70,5 +112,5 @@ volumes:
 
 networks:
   app-network:
-    external: true
     name: app_app-network
+    driver: bridge

--- a/pyeon/nginx.conf
+++ b/pyeon/nginx.conf
@@ -109,4 +109,30 @@ server {
         access_log off;
         proxy_read_timeout 3s;
     }
+    
+    # Prometheus 엔드포인트
+    location /prometheus/ {
+        auth_basic "Prometheus";
+        auth_basic_user_file /etc/nginx/.htpasswd.prometheus;
+        
+        proxy_pass http://app-prometheus-1:9090/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # Grafana 엔드포인트
+    location /grafana/ {
+        proxy_pass http://app-grafana-1:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # WebSocket 지원
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
 } 

--- a/pyeon/nginx.conf
+++ b/pyeon/nginx.conf
@@ -15,8 +15,11 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    # SSL 설정 최적화
-    # 참고: SSL 설정은 /etc/letsencrypt/options-ssl-nginx.conf에 포함되어 있으므로 중복 설정을 제거했습니다.
+    # SSL 설정 최적화 (options-ssl-nginx.conf에 포함되지 않은 설정만 유지)
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 8.8.8.8 8.8.4.4 valid=300s;
+    resolver_timeout 5s;
     
     # 보안 헤더 추가
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -25,6 +28,7 @@ server {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     add_header Content-Security-Policy "default-src 'self' https: data: 'unsafe-inline' 'unsafe-eval';" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()";
 
     # 프록시 버퍼 설정
     proxy_buffer_size 128k;
@@ -36,6 +40,38 @@ server {
     proxy_send_timeout 300;
     proxy_read_timeout 300;
     send_timeout 300;
+
+    # 압축 설정 추가
+    gzip on;
+    gzip_comp_level 5;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types
+        application/atom+xml
+        application/javascript
+        application/json
+        application/ld+json
+        application/manifest+json
+        application/rss+xml
+        application/vnd.geo+json
+        application/vnd.ms-fontobject
+        application/x-font-ttf
+        application/x-web-app-manifest+json
+        application/xhtml+xml
+        application/xml
+        font/opentype
+        image/bmp
+        image/svg+xml
+        image/x-icon
+        text/cache-manifest
+        text/css
+        text/plain
+        text/vcard
+        text/vnd.rim.location.xloc
+        text/vtt
+        text/x-component
+        text/x-cross-domain-policy;
 
     # 로그 설정
     access_log /var/log/nginx/api.pyeondongbu.access.log;
@@ -53,6 +89,9 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
+        
+        # 요청 버퍼 크기 제한
+        client_max_body_size 10M;
     }
 
     # 정적 파일 캐싱 설정

--- a/pyeon/prometheus.yml
+++ b/pyeon/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "spring-actuator"
+    metrics_path: "/actuator/prometheus"
+    static_configs:
+      - targets: ["app-blue:8080", "app-green:8080"]
+
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]


### PR DESCRIPTION
# 경량 수준 모니터링 설정

## 변경사항
1. **가벼운 모니터링 시스템 추가했음**: 서버에 부담 안 주려고 Prometheus랑 Grafana 컨테이너 리소스 제한해서 구성했음. CPU 0.5, 메모리 512M 정도로 설정해서 실제 서비스에 영향 없게 했고, 필요한 기능만 넣었음.

2. **Spring Boot Actuator 활용해서 연동했음**: 별도 에이전트 설치 없이 Spring Boot에서 제공하는 /actuator/prometheus 엔드포인트만 사용해서 JVM 메모리, CPU, API 응답시간 같은 중요 지표들 수집하게 했음. 코드 변경 최소화하면서 필요한 정보만 모니터링 가능하게 구성했음.

3. **보안 신경 쓰면서 CI/CD에 통합했음**: GitHub Actions에 모니터링 시스템 배포 과정 추가해서 코드 푸시하면 자동으로 모니터링까지 같이 배포되게 만들었음. 비밀번호는 GitHub Secrets로 관리해서 보안 유지했음.
