### PR TITLE
fix: Spring Security Permit 추가

### DIFF
--- a/pyeon/src/main/java/com/pyeon/global/config/SecurityConfig.java
+++ b/pyeon/src/main/java/com/pyeon/global/config/SecurityConfig.java
@@ -53,7 +53,10 @@ public class SecurityConfig {
                             "/oauth2/**",
                             "/api/images/**",
                             "/actuator/health",
-                            "/actuator/info"
+                            "/actuator/info",
+                            "/actuator/prometheus",
+                            "/prometheus/**",
+                            "/grafana/**"
                         ).permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
## 변경 내용
- Spring Security 설정에서 모니터링 경로를 인증 없이 접근 가능하도록 수정.

## 변경 이유
- 모니터링 도구에 접근할 때 Spring Security 인증이 필요해 로그인 페이지로 리다이렉트되는 발생.
- 이미 Nginx 기본 인증(Prometheus)과 자체 로그인 시스템(Grafana)으로 보호되고 있어 Spring Security 인증은 보안이 중복

## 보안 고려사항
- Prometheus는 여전히 Nginx 기본 인증으로 보호됩니다 (GitHub Secrets의 PROMETHEUS_PASSWORD 사용).
- Grafana는 자체 로그인 시스템으로 보호됩니다 (GitHub Secrets의 GRAFANA_ADMIN_PASSWORD 사용).
