### PR TITLE
fix: grafana 및 prometheus 인증 체계 변경

### DIFF
--- a/pyeon/docker-compose.prod.yml
+++ b/pyeon/docker-compose.prod.yml
@@ -31,7 +31,7 @@ services:
     image: mysql:8.0.26
     container_name: app-db-1
     expose:
-      - "3306"
+      - "3306:3306"
     environment:
       - MYSQL_DATABASE=pyeon
       - MYSQL_ROOT_PASSWORD=${PROD_DB_PASSWORD}
@@ -112,8 +112,10 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
-    ports:
-      - "9090:9090"
+    command:
+      - "--web.listen-address=127.0.0.1:9090"
+    expose:
+      - "9090"
     restart: always
     networks:
       - app-network
@@ -136,12 +138,15 @@ services:
     container_name: app-grafana-1
     volumes:
       - grafana_data:/var/lib/grafana
-    ports:
-      - "3000:3000"
+    command:
+      - "--serve_from_sub_path=true"
+    expose:
+      - "3000"
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_SERVER_HTTP_ADDR=127.0.0.1
     restart: always
     networks:
       - app-network


### PR DESCRIPTION
# grafana 및 prometheus 인증 체계 변경

## 변경 내용 요약
1. Prometheus 설정 변경
   - 외부 포트 노출(9090) 제거
   - 로컬호스트(127.0.0.1)에서만 접근 가능하도록 설정
   - 명령어 추가: '--web.listen-address=127.0.0.1:9090'
   - ports -> expose로 변경

2. Grafana 설정 변경
   - 외부 포트 노출(3000) 제거
   - 로컬호스트(127.0.0.1)에서만 접근 가능하도록 설정
   - 명령어 추가: '--serve_from_sub_path=true'
   - 환경변수 추가: 'GF_SERVER_HTTP_ADDR=127.0.0.1'
   - ports -> expose로 변경