### PR TITLE
refact: MySQL 익스포터 추가

### DIFF
--- a/pyeon/docker-compose.prod.yml
+++ b/pyeon/docker-compose.prod.yml
@@ -166,6 +166,35 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  mysql-exporter:
+    image: prom/mysqld-exporter:latest
+    container_name: app-mysql-exporter-1
+    environment:
+      - DATA_SOURCE_NAME=root:${PROD_DB_PASSWORD}@(db:3306)/
+    command:
+      - "--collect.info_schema.tables"
+      - "--collect.info_schema.innodb_metrics"
+    expose:
+      - "9104"
+    networks:
+      - app-network
+    restart: always
+    depends_on:
+      - db
+    deploy:
+      resources:
+        limits:
+          cpus: "0.2"
+          memory: 128M
+        reservations:
+          cpus: "0.1"
+          memory: 64M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
 volumes:
   mysql_data_prod:
   redis_data_prod:

--- a/pyeon/prometheus.yml
+++ b/pyeon/prometheus.yml
@@ -11,3 +11,7 @@ scrape_configs:
   - job_name: "prometheus"
     static_configs:
       - targets: ["localhost:9090"]
+
+  - job_name: "mysql"
+    static_configs:
+      - targets: ["mysql-exporter:9104"]


### PR DESCRIPTION
# MySQL 모니터링 익스포터 추가

## 변경 내용
- `docker-compose.prod.yml`에 MySQL 익스포터 서비스 추가
- `prometheus.yml`에 MySQL 스크랩 설정 추가

## 목적
- MySQL 데이터베이스 메트릭 수집 및 모니터링
- Grafana에서 MySQL 대시보드 활용 가능하게 함
- 데이터베이스 성능 문제 사전 탐지

## 주요 모니터링 항목
- MySQL 쿼리 성능 및 쿼리 수
- 데이터베이스 커넥션 상태
- 테이블 락 상태
- InnoDB 버퍼 풀 사용량
- 느린 쿼리 감지
