### PR TITLE
refact: mysql exporter 추가 및 모니터링 설정

### DIFF
--- a/pyeon/docker-compose.blue.yml
+++ b/pyeon/docker-compose.blue.yml
@@ -75,7 +75,7 @@ services:
       # 로깅 설정
       - logging.level.root=INFO
       - logging.level.com.pyeon=INFO
-      - logging.level.org.springframework.security=DEBUG
+      - logging.level.org.springframework.security=WARN
       - logging.file.name=/var/log/pyeon/application.log
     restart: always
     networks:
@@ -99,7 +99,22 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      test:
+        [
+          "CMD",
+          "java",
+          "-jar",
+          "/tmp/healthcheck.jar",
+          "||",
+          "java",
+          "-cp",
+          "/app/app.jar",
+          "org.springframework.boot.loader.launch.JarLauncher",
+          "--thin.dryrun",
+          "||",
+          "echo",
+          "0",
+        ]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/pyeon/docker-compose.green.yml
+++ b/pyeon/docker-compose.green.yml
@@ -75,7 +75,7 @@ services:
       # 로깅 설정
       - logging.level.root=INFO
       - logging.level.com.pyeon=INFO
-      - logging.level.org.springframework.security=DEBUG
+      - logging.level.org.springframework.security=WARN
       - logging.file.name=/var/log/pyeon/application.log
     restart: always
     networks:
@@ -99,7 +99,22 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      test:
+        [
+          "CMD",
+          "java",
+          "-jar",
+          "/tmp/healthcheck.jar",
+          "||",
+          "java",
+          "-cp",
+          "/app/app.jar",
+          "org.springframework.boot.loader.launch.JarLauncher",
+          "--thin.dryrun",
+          "||",
+          "echo",
+          "0",
+        ]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/pyeon/docker-compose.mysql-exporter.yml
+++ b/pyeon/docker-compose.mysql-exporter.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+  mysqld-exporter:
+    image: prom/mysqld-exporter:v0.12.1
+    container_name: app-mysqld-exporter
+    restart: always
+    environment:
+      - DATA_SOURCE_NAME=exporter:${MYSQL_EXPORTER_PASSWORD}@(app-db-1:3306)/
+    ports:
+      - "9104:9104"
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    external: true
+    name: app_app-network

--- a/pyeon/docker-compose.prod.yml
+++ b/pyeon/docker-compose.prod.yml
@@ -79,8 +79,8 @@ services:
   redis:
     image: redis:7.0
     container_name: app-redis-1
-    expose:
-      - "6379"
+    ports:
+      - "6379:6379"
     command: ["redis-server", "--requirepass", "${PROD_REDIS_PASSWORD}"]
     volumes:
       - redis_data_prod:/data
@@ -113,9 +113,9 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
     command:
-      - "--web.listen-address=127.0.0.1:9090"
-    expose:
-      - "9090"
+      - "--web.listen-address=0.0.0.0:9090"
+    ports:
+      - "9090:9090"
     restart: always
     networks:
       - app-network
@@ -138,15 +138,15 @@ services:
     container_name: app-grafana-1
     volumes:
       - grafana_data:/var/lib/grafana
-    command:
-      - "--serve_from_sub_path=true"
-    expose:
-      - "3000"
+    ports:
+      - "3000:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
-      - GF_SERVER_HTTP_ADDR=127.0.0.1
+      - GF_SERVER_HTTP_ADDR=0.0.0.0
+      - GF_SERVER_SERVE_FROM_SUB_PATH=false
+      - GF_SERVER_ROOT_URL=http://localhost:3000
     restart: always
     networks:
       - app-network

--- a/pyeon/prometheus.yml
+++ b/pyeon/prometheus.yml
@@ -11,3 +11,8 @@ scrape_configs:
   - job_name: "prometheus"
     static_configs:
       - targets: ["localhost:9090"]
+
+  - job_name: "mysql"
+    static_configs:
+      - targets: ["app-mysqld-exporter:9104"]
+    metrics_path: "/metrics"


### PR DESCRIPTION
# 변경사항
- MySQL Exporter(v0.12.1) 설정 및 배포 추가
- Prometheus 설정에 MySQL 모니터링 설정 추가
- Grafana에 MySQL 대시보드 연동 준비

# 고민한 점
## 1. MySQL Exporter 네트워크 설정
- 초기에 Docker 네트워크 불일치로 인해 Prometheus가 MySQL Exporter를 찾지 못함
- app_default와 app_app-network 네트워크가 분리되어 있었음
- MySQL Exporter를 app_app-network로 이동시켜 Prometheus와 동일 네트워크 사용하도록 수정

## 2. MySQL 보안 및 권한 설정
- 최소 권한 원칙 적용: exporter 계정에 필요한 권한만 부여(PROCESS, REPLICATION CLIENT, SELECT)
- 모든 호스트에서 접근 가능하도록 '%' 설정 (컨테이너 IP는 동적으로 변경될 수 있음)
- 환경 변수를 통한 비밀번호 관리로 보안 강화

## 3. 버전 호환성 문제
- 최신 버전의 MySQL Exporter에서 명령행 옵션 형식 변경으로 인한 오류 발생
- '--collect.process_list' 플래그 인식 오류
- v0.12.1 버전으로 다운그레이드하여 안정성 확보

## 4. CI/CD 통합 고려사항
- 인프라 관련 설정 파일(docker-compose.mysql-exporter.yml)은 CI/CD 자동 업데이트 제외

## 5. 도커 컴포즈 파일 분리
- 인프라 서비스와 애플리케이션 서비스 분리로 유지보수성 향상
- 기존 시스템과의 일관성 유지