### PR TITLE
refact: 차단된 유저에 대한 처리 추가

### DIFF
--- a/pyeon/src/main/java/com/pyeon/global/exception/ErrorCode.java
+++ b/pyeon/src/main/java/com/pyeon/global/exception/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
     MEMBER_SUSPENDED(HttpStatus.FORBIDDEN, "MEMBER_004", "일시 정지된 회원입니다."),
     MEMBER_BANNED(HttpStatus.FORBIDDEN, "MEMBER_005", "영구 정지된 회원입니다."),
     ADMIN_NOT_SUSPENDABLE(HttpStatus.FORBIDDEN, "MEMBER_006", "관리자는 제재할 수 없습니다."),
-    MEMBER_DEACTIVATED(HttpStatus.FORBIDDEN, "MEMBER_007", "비활성화된 회원입니다."),
+    MEMBER_DEACTIVATED(HttpStatus.FORBIDDEN, "MEMBER_007", "사용이 제한된 사용자이거나 탈퇴한 사용자입니다."),
 
     // Request 관련 에러
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "REQ_001", "잘못된 요청입니다."),


### PR DESCRIPTION
##  문제 상황
- 비활성화된(밴된) 회원이 로그인 시도 시 일반 500 서버 에러만 표시
- 사용자가 왜 로그인이 안 되는지 이해할 수 없음
- 서버 로그에도 일반 오류로만 기록되어 추적 어려움

##  개선 내용

###  OAuth 로그인 처리 개선
- CustomOAuth2UserService 클래스 수정
- 로그인 시 사용자 이메일로 계정 조회할 때 비활성화된 계정도 함께 조회
- 비활성화된 계정으로 로그인 시도 시 적절한 오류 발생 처리
- 로그에 비활성화된 계정의 로그인 시도 기록

## 처리 결과
- 비활성화된 계정 로그인 시 명확한 오류 메시지 제공
- 클라이언트에 JSON 형태로 다음 정보 전달:
  * 상태 코드: 403
  * 메시지: "사용이 제한된 사용자이거나 탈퇴한 사용자입니다."
- 사용자 경험 개선 및 지원 요청 시 명확한 상황 설명 가능