### PR TITLE
fix: 배포 스크립트 충돌 문제 해결

### DIFF
--- a/pyeon/deploy-blue-green.sh
+++ b/pyeon/deploy-blue-green.sh
@@ -171,7 +171,14 @@ fi
 
 # 새 컨테이너 실행 (대상 컨테이너)
 echo "새 컨테이너(app-$TARGET_COLOR) 시작 중..."
-docker-compose -f docker-compose.prod.yml -f docker-compose.$TARGET_COLOR.yml up -d app-$TARGET_COLOR
+docker-compose -f docker-compose.prod.yml -f docker-compose.$TARGET_COLOR.yml up -d --no-deps app-$TARGET_COLOR
+
+# 의존성 서비스 상태 확인
+REDIS_HEALTH=$(docker ps --filter "name=app-redis-1" --format "{{.Status}}" | grep -E "Up|running" || echo "")
+DB_HEALTH=$(docker ps --filter "name=app-db-1" --format "{{.Status}}" | grep -E "Up|running" || echo "")
+if [ -z "$REDIS_HEALTH" ] || [ -z "$DB_HEALTH" ]; then
+  echo "경고: Redis 또는 DB가 실행 중이 아닙니다. 애플리케이션이 제대로 동작하지 않을 수 있습니다."
+fi
 
 # 새 컨테이너가 정상적으로 실행되는지 확인
 echo "새 컨테이너 상태 확인 중... (최대 30초 대기)"


### PR DESCRIPTION
## 배포 스크립트 개선 - 의존성 서비스 재시작 방지

### 변경 내용
- 블루-그린 배포 스크립트(`deploy-blue-green.sh`)에 `--no-deps` 옵션 추가
- Redis, DB와 같은 의존성 서비스 상태 확인 로직 추가

### 문제 상황
- 새 컨테이너 배포 시 Redis와 같은 인프라 서비스가 재시작되는 문제 발생
- 이미 실행 중인 Redis 컨테이너가 있을 때 충돌 오류 발생
- 배포 실패로 인한 서비스 중단 위험

### 해결 방법
- `docker-compose up -d` 명령에 `--no-deps` 옵션을 추가하여 의존성 서비스 재시작 방지
- 애플리케이션 서비스만 업데이트하고 인프라 서비스는 유지
- 의존성 서비스 상태 확인 로직 추가로 문제 발생 시 경고 메시지 표시
