### PR TITLE
fix: 비활성화 유저 포함 검색 추가

### DIFF
--- a/pyeon/src/main/java/com/pyeon/domain/auth/service/AuthServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/service/AuthServiceImpl.java
@@ -87,7 +87,7 @@ public class AuthServiceImpl implements AuthService {
         Map<String, Object> attributes = oauth2User.getAttributes();
         String email = extractEmail(attributes);
 
-        Member member = memberRepository.findByEmailIncludeInactive(email)
+        Member member = memberRepository.findByEmailWithNativeSql(email)
                 .orElseThrow(() -> {
                     log.error("OAuth2 인증 완료된 사용자를 찾을 수 없음: {}", email);
                     return new CustomException(ErrorCode.MEMBER_NOT_FOUND);

--- a/pyeon/src/main/java/com/pyeon/domain/auth/service/CustomOAuth2UserService.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/service/CustomOAuth2UserService.java
@@ -44,8 +44,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private Member findOrCreateMember(Map<String, Object> attributes) {
         String email = (String) attributes.get("email");
-        
-        Optional<Member> memberOpt = memberRepository.findByEmailIncludeInactive(email);
+
+        Optional<Member> memberOpt = memberRepository.findByEmailWithNativeSql(email);
         
         if (memberOpt.isPresent()) {
             Member member = memberOpt.get();

--- a/pyeon/src/main/java/com/pyeon/domain/member/dao/MemberRepository.java
+++ b/pyeon/src/main/java/com/pyeon/domain/member/dao/MemberRepository.java
@@ -21,4 +21,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // isActive 상태와 관계없이 이메일로 멤버 찾기
     @Query("SELECT m FROM Member m WHERE m.email = :email")
     Optional<Member> findByEmailIncludeInactive(@Param("email") String email);
+    
+    // 네이티브 SQL을 사용하여 모든 상태의 회원을 찾는 메서드
+    @Query(value = "SELECT * FROM member WHERE email = :email", nativeQuery = true)
+    Optional<Member> findByEmailWithNativeSql(@Param("email") String email);
 }


### PR DESCRIPTION
# 비활성화된 계정 로그인 처리 문제 분석 및 해결

## 문제 상황
   - 비활성화된 계정(is_active=false)으로 로그인 시도 시 오류 발생:
     - 처음에는 "Duplicate entry 'pyeondongbu@gmail.com' for key" 오류(이메일 중복)
     - 코드 수정 후에는 "사용자를 찾을 수 없습니다" 오류

### 원인 분석
  - 엔티티 필터링 문제:
       - Member 엔티티에 @Where(clause = "is_active = true") 어노테이션 적용됨
       - 모든 기본 쿼리는 활성화된 계정만 조회하도록 제한됨
   
  - 쿼리 우회 실패:
       - JPQL로 @Where 조건을 우회하려 했으나 일부 JPA 구현체에서는 여전히 필터 적용됨
   
  - 코드 중복 및 불일치:
       - CustomOAuth2UserService와 AuthServiceImpl 두 클래스에서 동일 기능 중복 구현
       - 한쪽만 수정되어 불일치 발생

### 발생 프로세스
   - 사용자가 비활성화된 계정으로 로그인
   - CustomOAuth2UserService에서 사용자를 조회하지 못함(JPQL 우회가 작동하지 않음)
   - 없는 사용자로 판단하여 새 계정 생성 시도
   - 이메일이 동일하여 중복 오류 발생

### 해결책
   - 네이티브 SQL 쿼리 추가:
       - JPA 엔티티 필터링을 완전히 우회하는 네이티브 SQL 쿼리 사용
   
   - 두 클래스 모두 동일 메서드 사용:
       - CustomOAuth2UserService와 AuthServiceImpl 모두 findByEmailWithNativeSql 사용
       - 두 클래스에서 일관된 계정 조회 로직 적용
   
   -  명시적 비활성화 계정 검사:
       - 비활성화된 계정을 찾은 후 명시적으로 상태 확인하여 적절한 오류 반환
