### PR TITLE
fix: Oauth 인증 핸들러 코드 구조 문제 해결

### DIFF
--- a/pyeon/src/main/java/com/pyeon/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -2,6 +2,7 @@ package com.pyeon.domain.auth.handler;
 
 import com.pyeon.domain.auth.dto.response.TokenResponse;
 import com.pyeon.domain.auth.service.AuthService;
+import com.pyeon.global.exception.CustomException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +13,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.util.UriComponentsBuilder;
 import lombok.extern.slf4j.Slf4j;
-
-import java.io.IOException;
-import java.net.URI;
 
 @Slf4j
 @Component
@@ -30,33 +28,60 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             HttpServletRequest request,
             HttpServletResponse response,
             Authentication authentication
-    ) throws IOException {
-        log.info("OAuth2 인증 성공: {}", authentication.getName());
-        log.info("인증 객체 클래스: {}", authentication.getClass().getName());
-        log.info("인증 객체 세부 정보: {}", authentication.getDetails());
-        log.info("인증 객체 권한: {}", authentication.getAuthorities());
-        
-        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
-        log.info("OAuth2User 클래스: {}", oauth2User.getClass().getName());
-        log.info("OAuth2User 정보: {}", oauth2User.getAttributes());
-        
-        log.info("리다이렉트 URI 설정값: {}", redirectUri);
-        
+    ) {
         try {
-            TokenResponse tokenResponse = authService.createToken(oauth2User);
-            log.info("토큰 생성 완료: {}", tokenResponse.getAccessToken().substring(0, 10) + "...");
-
-            // 토큰을 URL 파라미터로 추가하여 리다이렉트
-            String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
-                    .queryParam("token", tokenResponse.getAccessToken())
-                    .build().toUriString();
-            
-            log.info("최종 리다이렉트 URL: {}", targetUrl);
-
+            String targetUrl = handleSuccessfulAuthentication(authentication);
             getRedirectStrategy().sendRedirect(request, response, targetUrl);
         } catch (Exception e) {
-            log.error("인증 성공 처리 중 오류 발생", e);
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "인증 처리 중 오류가 발생했습니다.");
+            handleAuthenticationError(request, response, e);
         }
+    }
+
+    private String handleSuccessfulAuthentication(Authentication authentication) {
+        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+        log.info("OAuth2User 정보: {}", oauth2User.getAttributes());
+        
+        TokenResponse tokenResponse = authService.createToken(oauth2User);
+        return buildSuccessUrl(tokenResponse);
+    }
+
+    private String buildSuccessUrl(TokenResponse tokenResponse) {
+        return UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("token", tokenResponse.getAccessToken())
+                .build().toUriString();
+    }
+
+    private void handleAuthenticationError(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Exception exception
+    ) {
+        String errorUrl = buildErrorUrl(exception);
+        try {
+            getRedirectStrategy().sendRedirect(request, response, errorUrl);
+        } catch (Exception e) {
+            log.error("리다이렉트 중 오류 발생", e);
+        }
+    }
+
+    private String buildErrorUrl(Exception exception) {
+        if (exception instanceof CustomException customException) {
+            return buildCustomErrorUrl(customException);
+        }
+        return buildGenericErrorUrl();
+    }
+
+    private String buildCustomErrorUrl(CustomException exception) {
+        return UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("error", exception.getErrorCode().name())
+                .queryParam("message", exception.getMessage())
+                .build().toUriString();
+    }
+
+    private String buildGenericErrorUrl() {
+        return UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("error", "AUTHENTICATION_FAILED")
+                .queryParam("message", "인증 처리 중 오류가 발생했습니다.")
+                .build().toUriString();
     }
 } 


### PR DESCRIPTION
# 실제 실패 원인

## 예외 처리 중 IOException이 발생
- OAuth2AuthenticationSuccessHandler에서 예외 발생 시 response.sendError()를 호출
- 문제점: sendError() 호출 후에는 더 이상 리다이렉트가 불가능
- 결과: 프론트엔드로 리다이렉트되지 않고 API 엔드포인트(/login/oauth2/code/google)에 갇힘

##  잘못된 에러 처리 흐름
현재 코드
- CustomException 발생 → AuthServiceImpl에서 MEMBER_DEACTIVATED 에러 발생
- OAuth2AuthenticationSuccessHandler에서 이를 잡아서 response.sendError() 호출
- sendError() 호출로 인해 리다이렉트 체인이 끊김
- 결과적으로 프론트엔드의 콜백 URL로 리다이렉트되지 않음

## 해결책
- response.sendError() 대신 리다이렉트 URL에 에러 파라미터를 포함하여 전달
- 프론트엔드의 콜백 URL로 항상 리다이렉트되도록 보장
- 에러 정보는 URL 파라미터로 전달하여 프론트엔드에서 처리 가능하게 함