### PR TITLE
fix: 토큰 생성 시 모든 예외를 한번에 처리

### DIFF
--- a/pyeon/src/main/java/com/pyeon/domain/auth/service/AuthServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/auth/service/AuthServiceImpl.java
@@ -43,8 +43,13 @@ public class AuthServiceImpl implements AuthService {
             } else {
                 return createTokenFromOAuth2User(oauth2User);
             }
-        } catch (Exception e) {
+        } catch (CustomException e) {
+            // CustomException은 그대로 전달
             log.error("토큰 생성 중 오류 발생", e);
+            throw e;
+        } catch (Exception e) {
+            // 다른 예외는 INVALID_TOKEN으로 변환
+            log.error("토큰 생성 중 예상치 못한 오류 발생", e);
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
     }


### PR DESCRIPTION
# [문제 진단]

## 원인 파악
   - AuthServiceImpl의 createToken 메서드에서 모든 예외를 INVALID_TOKEN으로 변환하는 코드:
   ```java
   try {
       // 토큰 생성 로직
   } catch (Exception e) { // 모든 예외를 한번에 처리
       log.error("토큰 생성 중 오류 발생", e);
       throw new CustomException(ErrorCode.INVALID_TOKEN); // 모든 예외가 INVALID_TOKEN으로 변환됨
   }
   ```
   
### 문제 상황
   - 비활성화된 계정 로그인 시도 → MEMBER_DEACTIVATED 예외 발생
   - 이 예외가 상위 메서드의 catch 블록에서 INVALID_TOKEN으로 변환됨
   - 결과적으로 프론트엔드에 잘못된 에러 코드 전달
   
## [해결 방법]

### 예외 처리 분리
   ```java
   try {
       // 토큰 생성 로직
   } catch (CustomException e) {
       // CustomException은 그대로 전달
       log.error("토큰 생성 중 오류 발생", e);
       throw e;
   } catch (Exception e) {
       // 다른 예외만 INVALID_TOKEN으로 변환
       log.error("토큰 생성 중 예상치 못한 오류 발생", e);
       throw new CustomException(ErrorCode.INVALID_TOKEN);
   }
   ```
