### PR TITLE
fix: 어드민 기능 권한 문제 해결

### DIFF
--- a/pyeon/src/main/java/com/pyeon/domain/post/service/CommentServiceImpl.java
+++ b/pyeon/src/main/java/com/pyeon/domain/post/service/CommentServiceImpl.java
@@ -42,7 +42,7 @@ public class CommentServiceImpl implements CommentService {
         Comment comment = findCommentById(commentId);
         Member member = memberFacade.getMemberById(memberId);
         
-        if (!comment.isWriter(member)) {
+        if (!member.isAdmin() && !comment.isWriter(member)) {
             throw new CustomException(ErrorCode.NOT_COMMENT_AUTHOR);
         }
         
@@ -55,7 +55,7 @@ public class CommentServiceImpl implements CommentService {
         Comment comment = findCommentById(commentId);
         Member member = memberFacade.getMemberById(memberId);
         
-        if (!comment.isWriter(member)) {
+        if (!member.isAdmin() && !comment.isWriter(member)) {
             throw new CustomException(ErrorCode.NOT_COMMENT_AUTHOR);
         }
         


### PR DESCRIPTION
# [문제 상황]
1. 어드민 계정으로 다른 사람의 게시글 삭제 시도 시 403 Forbidden 에러
2. 어드민 계정으로 다른 사람의 댓글 삭제 시도 시 401 Unauthorized 에러
3. "게시글의 작성자가 아닙니다", "댓글의 작성자가 아닙니다" 메시지 발생

# [원인 분석]
1. SecurityConfig: URL 패턴 권한 체크에서 DELETE 요청에 USER 역할만 허용
`   .requestMatchers(HttpMethod.DELETE, "/api/posts/**").hasRole("USER")`
   
2. 컨트롤러 수준(@PreAuthorize): 권한 체커만 사용하고 관리자 역할 직접 체크 부재
`   @PreAuthorize("@postAuthChecker.canModify(#id, principal)")`
   
3. 서비스 수준(CommentServiceImpl): 권한 체크에서 작성자만 확인하고 관리자 체크 부재
```
   if (!comment.isWriter(member)) {
       throw new CustomException(ErrorCode.NOT_COMMENT_AUTHOR);
   }
```

# [해결 방법]
1. SecurityConfig 수정: DELETE 요청에 USER와 ADMIN 모두 허용
`   .requestMatchers(HttpMethod.DELETE, "/api/posts/**").hasAnyRole("USER", "ADMIN")`
   
2. 컨트롤러 어노테이션 수정: 명시적으로 관리자 역할 체크 추가
`   @PreAuthorize("hasAnyRole('ADMIN') or (@postAuthChecker.canModify(#id, principal))")`
   
3. 서비스 구현체 수정: 관리자는 작성자 체크 우회하도록 로직 수정
```
   if (!member.isAdmin() && !comment.isWriter(member)) {
       throw new CustomException(ErrorCode.NOT_COMMENT_AUTHOR);
   }
```
